### PR TITLE
Fixed the issue of validation being triggered on delete section button being clicked

### DIFF
--- a/src/components/global/form/form-sections/ProfessionalSummary.tsx
+++ b/src/components/global/form/form-sections/ProfessionalSummary.tsx
@@ -36,7 +36,7 @@ const ProfessionalSummary: React.FC<ProfessionalSummaryProps> = ({
             />
           </CardTitle>
         )}
-        <button className="ml-auto" onClick={deleteSection}>
+        <button className="ml-auto" onClick={deleteSection} type="button">
           <Trash2Icon />
         </button>
       </CardHeader>


### PR DESCRIPTION
<!-- Add the issue/ticket number if available -->

# Summary

## Requirement:

The form validation was triggered when delete section button was clicked. Fix it.

## Changes made:

Just added the type="button" in the Professional Summary section's delete button. The issue was that since no type was set in the button, and in the DOM this button was being rendered inside a form, these buttons were also being considered as a submit button. So, the submit was being triggered when these delete button were clicked, and hence the validations were being triggered.

## How Has This Been Tested?

Jabba
![JabbaShahidGIF](https://github.com/amlan-roy/resume-craft/assets/59330872/e1c042a0-e8fa-475f-a11a-34b4e4d97316)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
