### PR TITLE
Updated the usage of Confirmation Dialog

### DIFF
--- a/__tests__/integration/components/global/__snapshots__/delete-confirmation-dialog.test.tsx.snap
+++ b/__tests__/integration/components/global/__snapshots__/delete-confirmation-dialog.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`integration:components/global/DeleteConfirmationDialog Does not render when open prop is not provided 1`] = `<div />`;
+
+exports[`integration:components/global/DeleteConfirmationDialog Passed in text copies render correctly 1`] = `
+<div
+  aria-hidden="true"
+  data-aria-hidden="true"
+/>
+`;
+
+exports[`integration:components/global/DeleteConfirmationDialog snapshot 1`] = `
+<div
+  aria-hidden="true"
+  data-aria-hidden="true"
+/>
+`;

--- a/__tests__/integration/components/global/delete-confirmation-dialog.test.tsx
+++ b/__tests__/integration/components/global/delete-confirmation-dialog.test.tsx
@@ -1,0 +1,74 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import DeleteConfirmationDialog from "@/components/global/DeleteConfirmationDialog";
+import userEvent from "@testing-library/user-event";
+
+describe("integration:components/global/DeleteConfirmationDialog", () => {
+  it("snapshot", () => {
+    const tree = render(<DeleteConfirmationDialog open />);
+    expect(tree.container).toMatchSnapshot();
+  });
+
+  it("Passed in text copies render correctly", () => {
+    const tree = render(
+      <DeleteConfirmationDialog
+        title="Tu Tu hai wahi dil ne jise apna kaha"
+        description="Tu hai jaha mai hu waha ab yeh jeena tere bin hai saza"
+        cancelText="Ho mil jaayein is tarah"
+        confirmText="do leharein jis tarah"
+        open
+      />
+    );
+    expect(
+      screen.getByText("Tu Tu hai wahi dil ne jise apna kaha")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Tu hai jaha mai hu waha ab yeh jeena tere bin hai saza")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ho mil jaayein is tarah")).toBeInTheDocument();
+    expect(screen.getByText("do leharein jis tarah")).toBeInTheDocument();
+
+    expect(tree.container).toMatchSnapshot();
+  });
+
+  it("Does not render when open prop is not provided", () => {
+    const tree = render(
+      <DeleteConfirmationDialog
+        title="Tu Tu hai wahi dil ne jise apna kaha"
+        description="Tu hai jaha mai hu waha ab yeh jeena tere bin hai saza"
+        cancelText="Ho mil jaayein is tarah"
+        confirmText="do leharein jis tarah"
+      />
+    );
+    expect(
+      screen.queryByText("Tu Tu hai wahi dil ne jise apna kaha")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Tu hai jaha mai hu waha ab yeh jeena tere bin hai saza"
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Ho mil jaayein is tarah")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("do leharein jis tarah")).not.toBeInTheDocument();
+
+    expect(tree.container).toMatchSnapshot();
+  });
+
+  it("Calls the passed onCancel callback on click of the cancel button", async () => {
+    const onCancel = jest.fn();
+    const user = userEvent.setup();
+    render(<DeleteConfirmationDialog open onCancel={onCancel} />);
+    await user.click(screen.getByRole("button", { name: /Cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("Calls the passed onConfirm callback on click of the cancel button", async () => {
+    const onConfirm = jest.fn();
+    const user = userEvent.setup();
+    render(<DeleteConfirmationDialog open onConfirm={onConfirm} />);
+    await user.click(screen.getByRole("button", { name: /Continue/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/(enter-data)/enter-data/page.tsx
+++ b/src/app/(enter-data)/enter-data/page.tsx
@@ -215,12 +215,9 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
                     return (
                       <ProfessionalSummary
                         key={field.id}
-                        deleteSection={() =>
-                          setAlertDialogState({
-                            index: sectionIndex,
-                            open: true,
-                          })
-                        }
+                        deleteSection={() => {
+                          deleteSection(sectionIndex);
+                        }}
                         index={sectionIndex}
                       />
                     );
@@ -228,13 +225,10 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
                     return (
                       <WorkExperience
                         key={field.id}
-                        deleteSection={() =>
-                          setAlertDialogState({
-                            index: sectionIndex,
-                            open: true,
-                          })
-                        }
-                        index={sectionIndex.toString()}
+                        deleteSection={() => {
+                          deleteSection(sectionIndex);
+                        }}
+                        index={sectionIndex}
                         fieldErrors={errors?.optionalSections?.[sectionIndex]}
                         fields={field.fields}
                         updateFields={(
@@ -264,12 +258,17 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
                             });
                             return;
                           }
-                          if (index) {
-                            const newFields = [...field.fields];
-                            newFields.splice(index, 1);
+                          if (index || index === 0) {
+                            const currentField = form.getValues()
+                              .optionalSections[sectionIndex] as z.infer<
+                              typeof workExperienceSectionSchema
+                            >;
+                            const currentFields = currentField?.fields;
+                            const updatedFields = [...(currentFields || [])];
+                            updatedFields.splice(index, 1);
                             updateSection(sectionIndex, {
-                              ...field,
-                              fields: newFields,
+                              ...currentField,
+                              fields: updatedFields,
                             });
                           }
                         }}
@@ -323,7 +322,7 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
           </form>
         </Form>
       </div>
-      <AlertDialog open={alertDialogState.open}>
+      {/* <AlertDialog open={alertDialogState.open}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
@@ -352,7 +351,7 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
-      </AlertDialog>
+      </AlertDialog> */}
     </>
   );
 };

--- a/src/components/global/DeleteConfirmationDialog.tsx
+++ b/src/components/global/DeleteConfirmationDialog.tsx
@@ -1,0 +1,65 @@
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+import React from "react";
+import {
+  AlertDialogHeader,
+  AlertDialogFooter,
+} from "@/components/ui/alert-dialog";
+import { AlertDialogProps } from "@radix-ui/react-alert-dialog";
+
+type DeleteConfirmationDialogProps = {
+  onCancel?: () => void;
+  onConfirm?: () => void;
+  cancelText?: string;
+  confirmText?: string;
+  description?: string;
+  open?: boolean;
+  title?: string;
+} & AlertDialogProps;
+
+const DeleteConfirmationDialog: React.FC<DeleteConfirmationDialogProps> = ({
+  onCancel,
+  onConfirm,
+  cancelText = "Cancel",
+  confirmText = "Continue",
+  description = "This action cannot be undone. This will permanently the data that you have entered for this section.",
+  title = "Do you want to delete this section?",
+  open,
+  ...rest
+}) => {
+  return (
+    <AlertDialog open={open} {...rest}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            onClick={() => {
+              onCancel?.();
+            }}
+            type="button"
+          >
+            {cancelText}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => {
+              onConfirm?.();
+            }}
+            type="button"
+          >
+            {confirmText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+export default DeleteConfirmationDialog;

--- a/src/components/global/form/form-sections/ProfessionalSummary.tsx
+++ b/src/components/global/form/form-sections/ProfessionalSummary.tsx
@@ -1,10 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 import { Trash2Icon } from "lucide-react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import TextInput from "@/components/global/form/form-inputs/TextInput";
 import HiddenInput from "@/components/global/form/form-inputs/HiddenInput";
 import { SECTION, formType } from "@/lib/types/form";
 import { useFormContext } from "react-hook-form";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import DeleteConfirmationDialog from "../../DeleteConfirmationDialog";
 
 type ProfessionalSummaryProps = {
   deleteSection: () => void;
@@ -12,6 +23,16 @@ type ProfessionalSummaryProps = {
 };
 
 const fieldName = "optionalSections";
+
+const TEXT_COPIES = {
+  MODAL: {
+    cancelText: "Cancel",
+    confirmText: "Confirm",
+    description:
+      "This action cannot be undone. This will permanently the data that you have entered for this section.",
+    title: "Do you want to delete this section?",
+  },
+};
 
 const ProfessionalSummary: React.FC<ProfessionalSummaryProps> = ({
   deleteSection,
@@ -21,69 +42,96 @@ const ProfessionalSummary: React.FC<ProfessionalSummaryProps> = ({
     register,
     formState: { errors },
   } = useFormContext<formType>();
+
+  const [modalState, setModalState] = useState<{
+    open: boolean;
+  }>({
+    open: false,
+  });
   return (
-    <Card
-      data-testid="form-sections__professional-summary"
-      data-card-type={SECTION.PROFESSIONAL_SUMMARY}
-    >
-      <HiddenInput
-        fieldName={
-          index !== undefined && index !== null
-            ? `${fieldName}.${index}.type`
-            : undefined
-        }
-        value={SECTION.PROFESSIONAL_SUMMARY}
-        register={register}
-      />
-      <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
-        <CardTitle className="w-full max-w-[75%]">
+    <>
+      <Card
+        data-testid="form-sections__professional-summary"
+        data-card-type={SECTION.PROFESSIONAL_SUMMARY}
+      >
+        <HiddenInput
+          fieldName={
+            index !== undefined && index !== null
+              ? `${fieldName}.${index}.type`
+              : undefined
+          }
+          value={SECTION.PROFESSIONAL_SUMMARY}
+          register={register}
+        />
+        <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
+          <CardTitle className="w-full max-w-[75%]">
+            <TextInput
+              fieldName={
+                index !== undefined && index !== null
+                  ? `${fieldName}.${index}.sectionTitle`
+                  : undefined
+              }
+              register={register}
+              inputClassName="text-xl md:text-2xl py-6"
+              placeholder="Section title"
+              errorMessage={
+                index !== undefined
+                  ? errors?.[fieldName]?.[index]?.sectionTitle?.message
+                  : undefined
+              }
+            />
+          </CardTitle>
+
+          <button
+            className="ml-auto"
+            onClick={() => {
+              setModalState({
+                open: true,
+              });
+            }}
+            type="button"
+            data-testid="form-sections__delete-icon"
+          >
+            <Trash2Icon />
+          </button>
+        </CardHeader>
+        <CardContent className="flex flex-wrap w-full gap-5">
           <TextInput
             fieldName={
               index !== undefined && index !== null
-                ? `${fieldName}.${index}.sectionTitle`
+                ? `${fieldName}.${index}.fields.value`
                 : undefined
             }
             register={register}
-            inputClassName="text-xl md:text-2xl py-6"
-            placeholder="Section title"
+            multiline
+            className="w-full"
+            placeholder="Galactic Theorist with decades of experience, specializing in unraveling the fabric of the cosmos and visiting islands. Proficient in quantum mechanics, general relativity, and little people. Experienced in solving complex quadratic equations."
             errorMessage={
               index !== undefined
-                ? errors?.[fieldName]?.[index]?.sectionTitle?.message
+                ? // todo: fix this later
+                  // @ts-expect-error: some ts error
+                  errors?.[fieldName]?.[index]?.fields?.value?.message
                 : undefined
             }
           />
-        </CardTitle>
+        </CardContent>
+      </Card>
 
-        <button
-          className="ml-auto"
-          onClick={deleteSection}
-          type="button"
-          data-testid="form-sections__delete-icon"
-        >
-          <Trash2Icon />
-        </button>
-      </CardHeader>
-      <CardContent className="flex flex-wrap w-full gap-5">
-        <TextInput
-          fieldName={
-            index !== undefined && index !== null
-              ? `${fieldName}.${index}.fields.value`
-              : undefined
-          }
-          register={register}
-          multiline
-          className="w-full"
-          placeholder="Galactic Theorist with decades of experience, specializing in unraveling the fabric of the cosmos and visiting islands. Proficient in quantum mechanics, general relativity, and little people. Experienced in solving complex quadratic equations."
-          errorMessage={
-            index !== undefined
-              ? // todo: fix this later
-                // @ts-expect-error: some ts error
-                errors?.[fieldName]?.[index]?.fields?.value?.message
-              : undefined
-          }
-        />
-      </CardContent>
-    </Card>
+      <DeleteConfirmationDialog
+        open={modalState.open}
+        onCancel={() => {
+          setModalState({ open: false });
+        }}
+        onConfirm={() => {
+          deleteSection?.();
+          setModalState({ open: false });
+        }}
+        title={TEXT_COPIES.MODAL.title}
+        description={TEXT_COPIES.MODAL.description}
+        cancelText={TEXT_COPIES.MODAL.cancelText}
+        confirmText={TEXT_COPIES.MODAL.confirmText}
+      />
+    </>
   );
 };
 export default ProfessionalSummary;

--- a/src/components/global/form/form-sections/WorkExperience.tsx
+++ b/src/components/global/form/form-sections/WorkExperience.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { PlusCircleIcon, Trash2Icon } from "lucide-react";
 import { useFormContext } from "react-hook-form";
 import {
@@ -14,14 +14,42 @@ import { SECTION, formType, workExperienceFieldSchema } from "@/lib/types/form";
 import { Button } from "@/components/ui/button";
 import DurationInput from "../form-inputs/DurationInput";
 import { z } from "zod";
+import DeleteConfirmationDialog from "../../DeleteConfirmationDialog";
 
 const fieldName = "optionalSections";
+
+const TEXT_COPIES = {
+  MODAL: {
+    DELETE_SECTION: {
+      cancelText: "Cancel",
+      confirmText: "Confirm",
+      description:
+        "This action cannot be undone. This will permanently the data that you have entered for this section.",
+      title: "Do you want to delete this section?",
+    },
+    DELETE_SUBSECTION: {
+      cancelText: "Cancel",
+      confirmText: "Confirm",
+      description:
+        "This action cannot be undone. This will permanently the data that you have entered for this sub-section.",
+      title: "Do you want to delete this sub-section?",
+    },
+    DELETE_LAST_SUBSECTION: {
+      cancelText: "Cancel",
+      confirmText: "Confirm",
+      description:
+        "This section should at least have one sub section. Since you're trying to delete the last sub section of this section, continuing with this action will delete the whole section and you will loose the data that you've entered in this section. Do you want to continue with this action?",
+      title:
+        "Deleting this sub-section will delete the whole section. Do you want to continue?",
+    },
+  },
+};
 
 type WorkExperienceProps = {
   //todo: Getting the error: "Types of property '_reset' are incompatible." in page.tsx where this WorkExperience component is called
   // Adding this any in the type to ignore the error for now, but will need to fix it later
   deleteSection: () => void;
-  index: string;
+  index: number;
   fieldErrors?: any;
   fields?: z.infer<typeof workExperienceFieldSchema>[];
   updateFields?: (addFields?: boolean, index?: number) => void;
@@ -35,152 +63,200 @@ const WorkExperience: React.FC<WorkExperienceProps> = ({
   updateFields,
 }) => {
   const { register } = useFormContext<formType>();
+  const [modalState, setModalState] = useState<{
+    open: boolean;
+    type: "DELETE_SECTION" | "DELETE_SUBSECTION" | "DELETE_LAST_SUBSECTION";
+    subsectionToDeleteIndex?: number;
+  }>({
+    open: false,
+    type: "DELETE_SECTION",
+  });
 
   return (
-    <Card data-card-type={SECTION.WORK_EXPERIENCE}>
-      <HiddenInput
-        fieldName={
-          fieldName && (index !== undefined || index !== null)
-            ? `${fieldName}.${index}.type`
-            : undefined
-        }
-        value={SECTION.WORK_EXPERIENCE}
-        register={register}
-      />
-      <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
-        <CardTitle className="w-full max-w-[75%]">
-          <TextInput
-            fieldName={
-              fieldName && (index !== undefined || index !== null)
-                ? `${fieldName}.${index}.sectionTitle`
-                : undefined
-            }
-            register={register}
-            inputClassName="text-xl md:text-2xl py-6"
-            placeholder="Section title"
-            errorMessage={fieldErrors?.sectionTitle?.message}
-          />
-        </CardTitle>
+    <>
+      <Card data-card-type={SECTION.WORK_EXPERIENCE}>
+        <HiddenInput
+          fieldName={
+            fieldName && (index !== undefined || index !== null)
+              ? `${fieldName}.${index}.type`
+              : undefined
+          }
+          value={SECTION.WORK_EXPERIENCE}
+          register={register}
+        />
+        <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
+          <CardTitle className="w-full max-w-[75%]">
+            <TextInput
+              fieldName={
+                fieldName && (index !== undefined || index !== null)
+                  ? `${fieldName}.${index}.sectionTitle`
+                  : undefined
+              }
+              register={register}
+              inputClassName="text-xl md:text-2xl py-6"
+              placeholder="Section title"
+              errorMessage={fieldErrors?.sectionTitle?.message}
+            />
+          </CardTitle>
 
-        <Button
-          className="ml-auto"
-          onClick={deleteSection}
-          type="button"
-          variant={"ghost"}
-          title="Delete this section"
-        >
-          <Trash2Icon />
-        </Button>
-      </CardHeader>
-      <CardContent className="flex flex-wrap w-full gap-5">
-        {fields?.map((field, subSectionIndex) => (
-          <Card
-            className="w-full"
-            key={`work-experience-${index}-subsection-${subSectionIndex}`}
+          <Button
+            className="ml-auto"
+            onClick={() => {
+              setModalState({
+                open: true,
+                type: "DELETE_SECTION",
+              });
+            }}
+            type="button"
+            variant={"ghost"}
+            title="Delete this section"
           >
-            <CardHeader className="items-end">
-              <Button
-                type="button"
-                variant={"ghost"}
-                className="w-fit"
-                onClick={() => updateFields?.(false, subSectionIndex)}
-                title="Delete this sub-section"
-              >
-                <Trash2Icon className=" w-5 h-5" />
-              </Button>
-            </CardHeader>
-            <CardContent className="flex flex-row flex-wrap gap-10">
-              <TextInput
-                fieldName={
-                  fieldName && (index !== undefined || index !== null)
-                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].jobTitle`
-                    : undefined
-                }
-                register={register}
-                label="Job Title"
-                autoComplete="organization-title"
-                placeholder="Jethalal Gada"
-                className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                errorMessage={
-                  fieldErrors?.fields[subSectionIndex]?.jobTitle?.message
-                }
-              />
-              <TextInput
-                fieldName={
-                  fieldName && (index !== undefined || index !== null)
-                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].companyName`
-                    : undefined
-                }
-                register={register}
-                label="Company Name"
-                autoComplete="organization"
-                placeholder="Gada Electronics"
-                className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                errorMessage={
-                  fieldErrors?.fields[subSectionIndex]?.companyName?.message
-                }
-              />
-              <TextInput
-                fieldName={
-                  fieldName && (index !== undefined || index !== null)
-                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].location`
-                    : undefined
-                }
-                register={register}
-                label="Location"
-                autoComplete="address-level2"
-                placeholder="Gokuldham Society"
-                className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                errorMessage={
-                  fieldErrors?.fields[subSectionIndex]?.location?.message
-                }
-              />
-              <DurationInput
-                fieldName={`${fieldName}.[${index}].fields.[${subSectionIndex}].duration`}
-                subFieldNames={{
-                  startDate: "startDate",
-                  endDate: "endDate",
-                  current: "current",
-                }}
-                labels={{
-                  startDate: "Start Date",
-                  endDate: "End Date",
-                  current: "I an currently working here",
-                }}
-              />
-              <TextInput
-                fieldName={
-                  fieldName && (index !== undefined || index !== null)
-                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].details`
-                    : undefined
-                }
-                label="Description"
-                multiline
-                register={register}
-                placeholder={
-                  "- Managed electronics store for 20+ years\n- Generated job opportunitites for many people\n- Earned a lot of money"
-                }
-                className="w-full"
-                errorMessage={
-                  fieldErrors?.fields[subSectionIndex]?.details?.message
-                }
-              />
-            </CardContent>
-          </Card>
-        ))}
-      </CardContent>
-      <CardFooter>
-        <Button
-          type="button"
-          variant={"outline"}
-          onClick={() => updateFields?.(true)}
-          className="py-6"
-        >
-          <PlusCircleIcon className="w-8 h-8 mr-4" />
-          <span className="text-base">Add Sub Section</span>
-        </Button>
-      </CardFooter>
-    </Card>
+            <Trash2Icon />
+          </Button>
+        </CardHeader>
+        <CardContent className="flex flex-wrap w-full gap-5">
+          {fields?.map((field, subSectionIndex) => (
+            <Card
+              className="w-full"
+              key={`work-experience-${index}-subsection-${subSectionIndex}`}
+            >
+              <CardHeader className="items-end">
+                <Button
+                  type="button"
+                  variant={"ghost"}
+                  className="w-fit"
+                  onClick={() =>
+                    setModalState({
+                      open: true,
+                      type:
+                        fields.length > 1
+                          ? "DELETE_SUBSECTION"
+                          : "DELETE_LAST_SUBSECTION",
+                      subsectionToDeleteIndex: subSectionIndex,
+                    })
+                  }
+                  title="Delete this sub-section"
+                >
+                  <Trash2Icon className=" w-5 h-5" />
+                </Button>
+              </CardHeader>
+              <CardContent className="flex flex-row flex-wrap gap-10">
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].jobTitle`
+                      : undefined
+                  }
+                  register={register}
+                  label="Job Title"
+                  autoComplete="organization-title"
+                  placeholder="Jethalal Gada"
+                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                  errorMessage={
+                    fieldErrors?.fields[subSectionIndex]?.jobTitle?.message
+                  }
+                />
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].companyName`
+                      : undefined
+                  }
+                  register={register}
+                  label="Company Name"
+                  autoComplete="organization"
+                  placeholder="Gada Electronics"
+                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                  errorMessage={
+                    fieldErrors?.fields[subSectionIndex]?.companyName?.message
+                  }
+                />
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].location`
+                      : undefined
+                  }
+                  register={register}
+                  label="Location"
+                  autoComplete="address-level2"
+                  placeholder="Gokuldham Society"
+                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                  errorMessage={
+                    fieldErrors?.fields[subSectionIndex]?.location?.message
+                  }
+                />
+                <DurationInput
+                  fieldName={`${fieldName}.[${index}].fields.[${subSectionIndex}].duration`}
+                  subFieldNames={{
+                    startDate: "startDate",
+                    endDate: "endDate",
+                    current: "current",
+                  }}
+                  labels={{
+                    startDate: "Start Date",
+                    endDate: "End Date",
+                    current: "I an currently working here",
+                  }}
+                />
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].details`
+                      : undefined
+                  }
+                  label="Description"
+                  multiline
+                  register={register}
+                  placeholder={
+                    "- Managed electronics store for 20+ years\n- Generated job opportunitites for many people\n- Earned a lot of money"
+                  }
+                  className="w-full"
+                  errorMessage={
+                    fieldErrors?.fields[subSectionIndex]?.details?.message
+                  }
+                />
+              </CardContent>
+            </Card>
+          ))}
+        </CardContent>
+        <CardFooter>
+          <Button
+            type="button"
+            variant={"outline"}
+            onClick={() => updateFields?.(true)}
+            className="py-6"
+          >
+            <PlusCircleIcon className="w-8 h-8 mr-4" />
+            <span className="text-base">Add Sub Section</span>
+          </Button>
+        </CardFooter>
+      </Card>
+      <DeleteConfirmationDialog
+        open={modalState.open}
+        onCancel={() => {
+          setModalState((prev) => ({
+            ...prev,
+            open: false,
+            subsectionToDeleteIndex: undefined,
+          }));
+        }}
+        onConfirm={() => {
+          ["DELETE_SECTION", "DELETE_LAST_SUBSECTION"].includes(modalState.type)
+            ? deleteSection?.()
+            : updateFields?.(false, modalState.subsectionToDeleteIndex);
+          setModalState((prev) => ({
+            ...prev,
+            open: false,
+            subsectionToDeleteIndex: undefined,
+          }));
+        }}
+        title={TEXT_COPIES.MODAL?.[modalState.type].title}
+        description={TEXT_COPIES.MODAL?.[modalState.type].description}
+        cancelText={TEXT_COPIES.MODAL?.[modalState.type].cancelText}
+        confirmText={TEXT_COPIES.MODAL?.[modalState.type].confirmText}
+      />
+    </>
   );
 };
 export default WorkExperience;


### PR DESCRIPTION
# Summary

## Requirement:

Move the confirmation dialog from the page component to the section components (because we need to show different dialogs on different button clicks. State management was becoming difficult and was unnecessarily increasing the code in the page component. So, need to move it into the individual sections where it is being used.)

## Changes made:

- Moved the Confirmation dialog from the page to a separate component `DeleteConfirmationDialog`.
- Added tests for that component
- Used this component inside the modals and managing its states inside these individual components.

## How Has This Been Tested?

- Tested the UI manually
- Wrote tests for some components
### Screenshots / Videos (If required)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
