### PR TITLE
Adding technical skills section

### DIFF
--- a/src/app/(enter-data)/enter-data/page.tsx
+++ b/src/app/(enter-data)/enter-data/page.tsx
@@ -61,7 +61,7 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
         },
         {
           type: SECTION.PROJECTS,
-          sectionTitle: "Projects",
+          sectionTitle: "Relevant Projects",
           fields: [
             {
               projectTitle: "",
@@ -384,14 +384,6 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
               </DropdownMenuContent>
             </DropdownMenu>
             <Button type="submit">Submit</Button>
-            <Button type="button" variant={"secondary"}>
-              {" "}
-              Print Values
-            </Button>
-            <Button type="button" variant={"secondary"}>
-              {" "}
-              Print Errors
-            </Button>
           </form>
         </Form>
       </div>

--- a/src/app/(enter-data)/enter-data/page.tsx
+++ b/src/app/(enter-data)/enter-data/page.tsx
@@ -10,6 +10,7 @@ import {
   formSchema,
   formType,
   projectsSectionSchema,
+  skillsSectionSchema,
   workExperienceSectionSchema,
 } from "@/lib/types/form";
 import BasicDetails from "@/components/global/form/form-sections/BasicDetails";
@@ -32,6 +33,7 @@ import { findFirstFocusable } from "@/lib/utils/findFirstFocusableElemInLastCard
 import WorkExperience from "@/components/global/form/form-sections/WorkExperience";
 import { z } from "zod";
 import Projects from "@/components/global/form/form-sections/Projects";
+import Skills from "@/components/global/form/form-sections/Skills";
 
 type EnterDataPageProps = {};
 
@@ -69,6 +71,15 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
               projectUrl: undefined,
               associatedWith: undefined,
               details: "",
+            },
+          ],
+        },
+        {
+          type: SECTION.SKILLS,
+          sectionTitle: "Technical Skills",
+          fields: [
+            {
+              skills: "",
             },
           ],
         },
@@ -129,6 +140,17 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
             {
               projectTitle: "",
               details: "",
+            },
+          ],
+        });
+        break;
+      case SECTION.SKILLS:
+        append({
+          sectionTitle: "Technical Skills",
+          type: SECTION.SKILLS,
+          fields: [
+            {
+              skills: "",
             },
           ],
         });
@@ -205,7 +227,7 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
         <Form {...form}>
           <form
             onSubmit={(e) => {
-              console.log(form.formState.errors);
+              e.preventDefault();
               submitHandler(e);
             }}
             className="space-y-8"
@@ -330,6 +352,57 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
                         }}
                       />
                     );
+
+                  case SECTION.SKILLS:
+                    return (
+                      <Skills
+                        key={field.id}
+                        deleteSection={() => {
+                          deleteSection(sectionIndex);
+                        }}
+                        index={sectionIndex}
+                        fieldErrors={errors?.optionalSections?.[sectionIndex]}
+                        fields={field.fields}
+                        updateFields={(
+                          addFields?: boolean,
+                          index?: number
+                        ): void => {
+                          if (addFields) {
+                            // Directly using form.fields here causes an issue where when we click the add section button after the form is first rendered and if the subsections have some value in it, then
+                            // the form.fields will not have the values from the UI. And hence when the button is clicked and a new section is added, then the previous values are lost
+                            // However, after this, the values in form.fields are updated correctly and no values are lost on subsequent subsection additions.
+                            // So we need to use form.getValues instead
+                            const currentField = form.getValues()
+                              .optionalSections[sectionIndex] as z.infer<
+                              typeof skillsSectionSchema
+                            >;
+                            const currentFields = currentField?.fields;
+                            const updatedFields = [...(currentFields || [])];
+                            updatedFields.push({
+                              skills: "",
+                            });
+                            updateSection(sectionIndex, {
+                              ...currentField,
+                              fields: updatedFields,
+                            });
+                            return;
+                          }
+                          if (index || index === 0) {
+                            const currentField = form.getValues()
+                              .optionalSections[sectionIndex] as z.infer<
+                              typeof skillsSectionSchema
+                            >;
+                            const currentFields = currentField?.fields;
+                            const updatedFields = [...(currentFields || [])];
+                            updatedFields.splice(index, 1);
+                            updateSection(sectionIndex, {
+                              ...currentField,
+                              fields: updatedFields,
+                            });
+                          }
+                        }}
+                      />
+                    );
                 }
               })}
             </section>
@@ -380,6 +453,15 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
                   }}
                 >
                   Projects
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  data-add-section-menu-item="SKILLS"
+                  onSelect={() => {
+                    setFocusOnLastSection(true);
+                    addSection(SECTION.SKILLS);
+                  }}
+                >
+                  Skills
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/src/components/global/form/form-sections/ProfessionalSummary.tsx
+++ b/src/components/global/form/form-sections/ProfessionalSummary.tsx
@@ -5,16 +5,6 @@ import TextInput from "@/components/global/form/form-inputs/TextInput";
 import HiddenInput from "@/components/global/form/form-inputs/HiddenInput";
 import { SECTION, formType } from "@/lib/types/form";
 import { useFormContext } from "react-hook-form";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import DeleteConfirmationDialog from "../../DeleteConfirmationDialog";
 
 type ProfessionalSummaryProps = {

--- a/src/components/global/form/form-sections/Skills.tsx
+++ b/src/components/global/form/form-sections/Skills.tsx
@@ -1,0 +1,214 @@
+import React, { useState } from "react";
+import { PlusCircleIcon, Trash2Icon } from "lucide-react";
+import { useFormContext } from "react-hook-form";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import HiddenInput from "@/components/global/form/form-inputs/HiddenInput";
+import TextInput from "@/components/global/form/form-inputs/TextInput";
+import { SECTION, formType, skillsFieldSchema } from "@/lib/types/form";
+import { Button } from "@/components/ui/button";
+import { z } from "zod";
+import DeleteConfirmationDialog from "../../DeleteConfirmationDialog";
+
+const fieldName = "optionalSections";
+
+const TEXT_COPIES = {
+  MODAL: {
+    DELETE_SECTION: {
+      cancelText: "Cancel",
+      confirmText: "Confirm",
+      description:
+        "This action cannot be undone. This will permanently the data that you have entered for this section.",
+      title: "Do you want to delete this section?",
+    },
+    DELETE_SUBSECTION: {
+      cancelText: "Cancel",
+      confirmText: "Confirm",
+      description:
+        "This action cannot be undone. This will permanently the data that you have entered for this sub-section.",
+      title: "Do you want to delete this sub-section?",
+    },
+    DELETE_LAST_SUBSECTION: {
+      cancelText: "Cancel",
+      confirmText: "Confirm",
+      description:
+        "This section should at least have one sub section. Since you're trying to delete the last sub section of this section, continuing with this action will delete the whole section and you will loose the data that you've entered in this section. Do you want to continue with this action?",
+      title:
+        "Deleting this sub-section will delete the whole section. Do you want to continue?",
+    },
+  },
+};
+
+type SkillsProps = {
+  //todo: Getting the error: "Types of property '_reset' are incompatible." in page.tsx where this Skills component is called
+  // Adding this any in the type to ignore the error for now, but will need to fix it later
+  deleteSection: () => void;
+  index: number;
+  fieldErrors?: any;
+  fields?: z.infer<typeof skillsFieldSchema>[];
+  updateFields?: (addFields?: boolean, index?: number) => void;
+};
+
+const Skills: React.FC<SkillsProps> = ({
+  deleteSection,
+  index,
+  fieldErrors,
+  fields,
+  updateFields,
+}) => {
+  const { register } = useFormContext<formType>();
+  const [modalState, setModalState] = useState<{
+    open: boolean;
+    type: "DELETE_SECTION" | "DELETE_SUBSECTION" | "DELETE_LAST_SUBSECTION";
+    subsectionToDeleteIndex?: number;
+  }>({
+    open: false,
+    type: "DELETE_SECTION",
+  });
+
+  return (
+    <>
+      <Card data-card-type={SECTION.PROJECTS}>
+        <HiddenInput
+          fieldName={
+            fieldName && (index !== undefined || index !== null)
+              ? `${fieldName}.${index}.type`
+              : undefined
+          }
+          value={SECTION.PROJECTS}
+          register={register}
+        />
+        <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
+          <CardTitle className="w-full max-w-[75%]">
+            <TextInput
+              fieldName={
+                fieldName && (index !== undefined || index !== null)
+                  ? `${fieldName}.${index}.sectionTitle`
+                  : undefined
+              }
+              register={register}
+              inputClassName="text-xl md:text-2xl py-6"
+              placeholder="Technical Skills"
+              errorMessage={fieldErrors?.sectionTitle?.message}
+            />
+          </CardTitle>
+
+          <Button
+            className="ml-auto"
+            onClick={() => {
+              setModalState({
+                open: true,
+                type: "DELETE_SECTION",
+              });
+            }}
+            type="button"
+            variant={"ghost"}
+            title="Delete this section"
+          >
+            <Trash2Icon />
+          </Button>
+        </CardHeader>
+        <CardContent className="flex flex-wrap w-full gap-5">
+          {fields?.map((field, subSectionIndex) => (
+            <Card
+              className="w-full"
+              key={`projects-${index}-subsection-${subSectionIndex}`}
+            >
+              <CardContent className="mt-5 flex items-center">
+                <div className="flex flex-row flex-wrap gap-10 w-full">
+                  <TextInput
+                    fieldName={
+                      fieldName && (index !== undefined || index !== null)
+                        ? `${fieldName}.[${index}].fields.[${subSectionIndex}].title`
+                        : undefined
+                    }
+                    register={register}
+                    label="Skill Type"
+                    placeholder="Finance"
+                    className="w-full  md:max-w-[30%]"
+                    errorMessage={
+                      fieldErrors?.fields[subSectionIndex]?.title?.message
+                    }
+                  />
+                  <TextInput
+                    fieldName={
+                      fieldName && (index !== undefined || index !== null)
+                        ? `${fieldName}.[${index}].fields.[${subSectionIndex}].skills`
+                        : undefined
+                    }
+                    label="Skills"
+                    register={register}
+                    placeholder="Accounting, Calculator Expert, Tax Calculations, Counting Money ..."
+                    className="w-full lg:max-w-[60%] md:max-w-[55%]"
+                    errorMessage={
+                      fieldErrors?.fields[subSectionIndex]?.skills?.message
+                    }
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant={"ghost"}
+                  className="w-fit"
+                  onClick={() =>
+                    setModalState({
+                      open: true,
+                      type:
+                        fields.length > 1
+                          ? "DELETE_SUBSECTION"
+                          : "DELETE_LAST_SUBSECTION",
+                      subsectionToDeleteIndex: subSectionIndex,
+                    })
+                  }
+                  title="Delete this sub-section"
+                >
+                  <Trash2Icon className=" w-5 h-5" />
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </CardContent>
+        <CardFooter>
+          <Button
+            type="button"
+            variant={"outline"}
+            onClick={() => updateFields?.(true)}
+            className="py-6"
+          >
+            <PlusCircleIcon className="w-8 h-8 mr-4" />
+            <span className="text-base">Add Sub Section</span>
+          </Button>
+        </CardFooter>
+      </Card>
+      <DeleteConfirmationDialog
+        open={modalState.open}
+        onCancel={() => {
+          setModalState((prev) => ({
+            ...prev,
+            open: false,
+            subsectionToDeleteIndex: undefined,
+          }));
+        }}
+        onConfirm={() => {
+          ["DELETE_SECTION", "DELETE_LAST_SUBSECTION"].includes(modalState.type)
+            ? deleteSection?.()
+            : updateFields?.(false, modalState.subsectionToDeleteIndex);
+          setModalState((prev) => ({
+            ...prev,
+            open: false,
+            subsectionToDeleteIndex: undefined,
+          }));
+        }}
+        title={TEXT_COPIES.MODAL?.[modalState.type].title}
+        description={TEXT_COPIES.MODAL?.[modalState.type].description}
+        cancelText={TEXT_COPIES.MODAL?.[modalState.type].cancelText}
+        confirmText={TEXT_COPIES.MODAL?.[modalState.type].confirmText}
+      />
+    </>
+  );
+};
+export default Skills;

--- a/src/lib/types/form.ts
+++ b/src/lib/types/form.ts
@@ -98,16 +98,11 @@ export const projectsFieldSchema = z.object({
   duration: durationFieldSchema.optional().nullish(),
   details: z.string().optional().nullish().or(z.literal("")),
 });
-export const skillsFieldSchema = z.union([
-  z
-    .object({
-      title: z.string(),
-      skills: z.string(),
-    })
-    .optional()
-    .nullish(),
-  z.string().optional().nullish().or(z.literal("")),
-]);
+export const skillsFieldSchema = z.object({
+  title: z.string().optional().nullish().or(z.literal("")),
+  skills: z.string().min(1, "This is a required skill"),
+});
+
 export const educationFieldSchema = z.object({
   universityName: z.string(),
   degreeName: z.string(),


### PR DESCRIPTION
Ticket: https://github.com/amlan-roy/resume-craft/issues/16

# Summary
## Requirement:

- All the input fields should work.
- The `Field Name` should also be an optional input.
- If no field name is given, then in the final resume only list items will be entered. If field name is given, then field name will be bold, and in it's right, there will be the other options.
- The big delete button on top deletes the whole section.
- The smaller delete button deletes the individual fields.
- The small plus below adds the sub section.

## Changes made:

- Removed extra buttons from the page and more
- Added the skills section (similar to previous changes)

### Note:
Updated the UI during dev because I felt that the updated UI is a bit clearer.

## How Has This Been Tested?
Tested the UI by running the repo locally.

### Screenshots / Videos (If required)
| Dark Mode | Light Mode |
| -- | -- |
| ![image](https://github.com/amlan-roy/resume-craft/assets/59330872/82476a95-5a85-4499-a1b6-bf25467cb49e) | ![image](https://github.com/amlan-roy/resume-craft/assets/59330872/f5bd0d2c-9be5-4fe9-b2a1-204db06e7f3e) |
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
