### PR TITLE
Added the education section

### DIFF
--- a/src/app/(enter-data)/enter-data/page.tsx
+++ b/src/app/(enter-data)/enter-data/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import {
   SECTION,
+  educationSectionSchema,
   formSchema,
   formType,
   projectsSectionSchema,
@@ -34,6 +35,7 @@ import WorkExperience from "@/components/global/form/form-sections/WorkExperienc
 import { z } from "zod";
 import Projects from "@/components/global/form/form-sections/Projects";
 import Skills from "@/components/global/form/form-sections/Skills";
+import Education from "@/components/global/form/form-sections/Education";
 
 type EnterDataPageProps = {};
 
@@ -80,6 +82,19 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
           fields: [
             {
               skills: "",
+            },
+          ],
+        },
+        {
+          type: SECTION.EDUCATION,
+          sectionTitle: "Education",
+          fields: [
+            {
+              universityName: "",
+              degreeName: "",
+              majorName: "",
+              grade: "",
+              location: "",
             },
           ],
         },
@@ -151,6 +166,21 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
           fields: [
             {
               skills: "",
+            },
+          ],
+        });
+        break;
+      case SECTION.EDUCATION:
+        append({
+          sectionTitle: "Education",
+          type: SECTION.EDUCATION,
+          fields: [
+            {
+              universityName: "",
+              degreeName: "",
+              majorName: "",
+              grade: "",
+              location: "",
             },
           ],
         });
@@ -403,6 +433,57 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
                         }}
                       />
                     );
+                  case SECTION.EDUCATION:
+                    return (
+                      <Education
+                        key={field.id}
+                        deleteSection={() => {
+                          deleteSection(sectionIndex);
+                        }}
+                        index={sectionIndex}
+                        fieldErrors={errors?.optionalSections?.[sectionIndex]}
+                        fields={field.fields}
+                        updateFields={(
+                          addFields?: boolean,
+                          index?: number
+                        ): void => {
+                          if (addFields) {
+                            // Directly using form.fields here causes an issue where when we click the add section button after the form is first rendered and if the subsections have some value in it, then
+                            // the form.fields will not have the values from the UI. And hence when the button is clicked and a new section is added, then the previous values are lost
+                            // However, after this, the values in form.fields are updated correctly and no values are lost on subsequent subsection additions.
+                            // So we need to use form.getValues instead
+                            const currentField = form.getValues()
+                              .optionalSections[sectionIndex] as z.infer<
+                              typeof educationSectionSchema
+                            >;
+                            const currentFields = currentField?.fields;
+                            const updatedFields = [...(currentFields || [])];
+                            updatedFields.push({
+                              universityName: "",
+                              degreeName: "",
+                            });
+                            updateSection(sectionIndex, {
+                              ...currentField,
+                              fields: updatedFields,
+                            });
+                            return;
+                          }
+                          if (index || index === 0) {
+                            const currentField = form.getValues()
+                              .optionalSections[sectionIndex] as z.infer<
+                              typeof educationSectionSchema
+                            >;
+                            const currentFields = currentField?.fields;
+                            const updatedFields = [...(currentFields || [])];
+                            updatedFields.splice(index, 1);
+                            updateSection(sectionIndex, {
+                              ...currentField,
+                              fields: updatedFields,
+                            });
+                          }
+                        }}
+                      />
+                    );
                 }
               })}
             </section>
@@ -462,6 +543,15 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
                   }}
                 >
                   Skills
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  data-add-section-menu-item="EDUCATION"
+                  onSelect={() => {
+                    setFocusOnLastSection(true);
+                    addSection(SECTION.EDUCATION);
+                  }}
+                >
+                  Education
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/src/components/global/form/form-sections/Education.tsx
+++ b/src/components/global/form/form-sections/Education.tsx
@@ -1,0 +1,274 @@
+import React, { useState } from "react";
+import { PlusCircleIcon, Trash2Icon } from "lucide-react";
+import { useFormContext } from "react-hook-form";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import HiddenInput from "@/components/global/form/form-inputs/HiddenInput";
+import TextInput from "@/components/global/form/form-inputs/TextInput";
+import { SECTION, educationFieldSchema, formType } from "@/lib/types/form";
+import { Button } from "@/components/ui/button";
+import DurationInput from "../form-inputs/DurationInput";
+import { z } from "zod";
+import DeleteConfirmationDialog from "../../DeleteConfirmationDialog";
+
+const fieldName = "optionalSections";
+
+const TEXT_COPIES = {
+  MODAL: {
+    DELETE_SECTION: {
+      cancelText: "Cancel",
+      confirmText: "Confirm",
+      description:
+        "This action cannot be undone. This will permanently the data that you have entered for this section.",
+      title: "Do you want to delete this section?",
+    },
+    DELETE_SUBSECTION: {
+      cancelText: "Cancel",
+      confirmText: "Confirm",
+      description:
+        "This action cannot be undone. This will permanently the data that you have entered for this sub-section.",
+      title: "Do you want to delete this sub-section?",
+    },
+    DELETE_LAST_SUBSECTION: {
+      cancelText: "Cancel",
+      confirmText: "Confirm",
+      description:
+        "This section should at least have one sub section. Since you're trying to delete the last sub section of this section, continuing with this action will delete the whole section and you will loose the data that you've entered in this section. Do you want to continue with this action?",
+      title:
+        "Deleting this sub-section will delete the whole section. Do you want to continue?",
+    },
+  },
+};
+
+type EducationProps = {
+  //todo: Getting the error: "Types of property '_reset' are incompatible." in page.tsx where this Education component is called
+  // Adding this any in the type to ignore the error for now, but will need to fix it later
+  deleteSection: () => void;
+  index: number;
+  fieldErrors?: any;
+  fields?: z.infer<typeof educationFieldSchema>[];
+  updateFields?: (addFields?: boolean, index?: number) => void;
+};
+
+const Education: React.FC<EducationProps> = ({
+  deleteSection,
+  index,
+  fieldErrors,
+  fields,
+  updateFields,
+}) => {
+  const { register } = useFormContext<formType>();
+  const [modalState, setModalState] = useState<{
+    open: boolean;
+    type: "DELETE_SECTION" | "DELETE_SUBSECTION" | "DELETE_LAST_SUBSECTION";
+    subsectionToDeleteIndex?: number;
+  }>({
+    open: false,
+    type: "DELETE_SECTION",
+  });
+
+  return (
+    <>
+      <Card data-card-type={SECTION.EDUCATION}>
+        <HiddenInput
+          fieldName={
+            fieldName && (index !== undefined || index !== null)
+              ? `${fieldName}.${index}.type`
+              : undefined
+          }
+          value={SECTION.EDUCATION}
+          register={register}
+        />
+        <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
+          <CardTitle className="w-full max-w-[75%]">
+            <TextInput
+              fieldName={
+                fieldName && (index !== undefined || index !== null)
+                  ? `${fieldName}.${index}.sectionTitle`
+                  : undefined
+              }
+              register={register}
+              inputClassName="text-xl md:text-2xl py-6"
+              placeholder="Section title"
+              errorMessage={fieldErrors?.sectionTitle?.message}
+            />
+          </CardTitle>
+
+          <Button
+            className="ml-auto"
+            onClick={() => {
+              setModalState({
+                open: true,
+                type: "DELETE_SECTION",
+              });
+            }}
+            type="button"
+            variant={"ghost"}
+            title="Delete this section"
+          >
+            <Trash2Icon />
+          </Button>
+        </CardHeader>
+        <CardContent className="flex flex-wrap w-full gap-5">
+          {fields?.map((field, subSectionIndex) => (
+            <Card
+              className="w-full"
+              key={`work-experience-${index}-subsection-${subSectionIndex}`}
+            >
+              <CardHeader className="items-end">
+                <Button
+                  type="button"
+                  variant={"ghost"}
+                  className="w-fit"
+                  onClick={() =>
+                    setModalState({
+                      open: true,
+                      type:
+                        fields.length > 1
+                          ? "DELETE_SUBSECTION"
+                          : "DELETE_LAST_SUBSECTION",
+                      subsectionToDeleteIndex: subSectionIndex,
+                    })
+                  }
+                  title="Delete this sub-section"
+                >
+                  <Trash2Icon className=" w-5 h-5" />
+                </Button>
+              </CardHeader>
+              <CardContent className="flex flex-row flex-wrap gap-10">
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].universityName`
+                      : undefined
+                  }
+                  register={register}
+                  label="University Name"
+                  autoComplete="organization-title"
+                  placeholder="College of Delusion and Anxiety"
+                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                  errorMessage={
+                    fieldErrors?.fields[subSectionIndex]?.universityName
+                      ?.message
+                  }
+                />
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].degreeName`
+                      : undefined
+                  }
+                  register={register}
+                  label="Degree Name"
+                  placeholder="Bachelors of Exestential Crisis"
+                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                  errorMessage={
+                    fieldErrors?.fields[subSectionIndex]?.degreeName?.message
+                  }
+                />
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].majorName`
+                      : undefined
+                  }
+                  register={register}
+                  label="Major Name"
+                  placeholder="Panic Attack"
+                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                  errorMessage={
+                    fieldErrors?.fields[subSectionIndex]?.majorName?.message
+                  }
+                />
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].grade`
+                      : undefined
+                  }
+                  register={register}
+                  label="Grade"
+                  placeholder="9.9/10"
+                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                  errorMessage={
+                    fieldErrors?.fields[subSectionIndex]?.grade?.message
+                  }
+                />
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].location`
+                      : undefined
+                  }
+                  register={register}
+                  label="Location"
+                  autoComplete="address-level1"
+                  placeholder="Powder Gully, Mumbai"
+                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                  errorMessage={
+                    fieldErrors?.fields[subSectionIndex]?.location?.message
+                  }
+                />
+
+                <DurationInput
+                  fieldName={`${fieldName}.[${index}].fields.[${subSectionIndex}].duration`}
+                  subFieldNames={{
+                    startDate: "startDate",
+                    endDate: "endDate",
+                    current: "current",
+                  }}
+                  labels={{
+                    startDate: "Start Date",
+                    endDate: "End Date",
+                    current: "I an currently Studying here",
+                  }}
+                />
+              </CardContent>
+            </Card>
+          ))}
+        </CardContent>
+        <CardFooter>
+          <Button
+            type="button"
+            variant={"outline"}
+            onClick={() => updateFields?.(true)}
+            className="py-6"
+          >
+            <PlusCircleIcon className="w-8 h-8 mr-4" />
+            <span className="text-base">Add Sub Section</span>
+          </Button>
+        </CardFooter>
+      </Card>
+      <DeleteConfirmationDialog
+        open={modalState.open}
+        onCancel={() => {
+          setModalState((prev) => ({
+            ...prev,
+            open: false,
+            subsectionToDeleteIndex: undefined,
+          }));
+        }}
+        onConfirm={() => {
+          ["DELETE_SECTION", "DELETE_LAST_SUBSECTION"].includes(modalState.type)
+            ? deleteSection?.()
+            : updateFields?.(false, modalState.subsectionToDeleteIndex);
+          setModalState((prev) => ({
+            ...prev,
+            open: false,
+            subsectionToDeleteIndex: undefined,
+          }));
+        }}
+        title={TEXT_COPIES.MODAL?.[modalState.type].title}
+        description={TEXT_COPIES.MODAL?.[modalState.type].description}
+        cancelText={TEXT_COPIES.MODAL?.[modalState.type].cancelText}
+        confirmText={TEXT_COPIES.MODAL?.[modalState.type].confirmText}
+      />
+    </>
+  );
+};
+export default Education;

--- a/src/lib/types/form.ts
+++ b/src/lib/types/form.ts
@@ -104,8 +104,8 @@ export const skillsFieldSchema = z.object({
 });
 
 export const educationFieldSchema = z.object({
-  universityName: z.string(),
-  degreeName: z.string(),
+  universityName: z.string().min(1, "University Name is required"),
+  degreeName: z.string().min(1, "Degree Name is required"),
   majorName: z.string().optional().nullish().or(z.literal("")),
   grade: z.string().optional().nullish().or(z.literal("")),
   location: z.string().optional().nullish().or(z.literal("")),


### PR DESCRIPTION
Issue: https://github.com/amlan-roy/resume-craft/issues/17
# Summary

## Requirement:

- All the input fields should work.
- For the date field, "current"/end date are mutually exclusive (But optional).
  - If current/end date is selected, then start date is required.
- The big delete button on top deletes the whole section.
- The smaller delete button deletes the sub sections.
- The small plus below adds the sub section.

## Changes made:

- Added the Education section component
- Updated the default form state, the add section button and the method used in it as well

## How Has This Been Tested?

Tested the UI by running the repo locally

### Screenshots / Videos (If required)

| Dark Mode | Light Mode |
| -- | -- |
| ![image](https://github.com/amlan-roy/resume-craft/assets/59330872/8ee06c3a-37cf-4066-84f0-e1f57244f25e) | ![image](https://github.com/amlan-roy/resume-craft/assets/59330872/1f64843f-6ada-480d-b650-2c3d4e136389) |

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
