### PR TITLE
Add resume generation API support for base resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-toast": "^1.1.5",
         "@testing-library/user-event": "^14.5.2",
+        "axios": "^1.6.7",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "date-fns": "^3.2.0",
@@ -3639,8 +3640,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.16",
@@ -3697,6 +3697,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -4283,7 +4293,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4542,7 +4551,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5606,6 +5614,25 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -5633,7 +5660,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8279,7 +8305,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8288,7 +8313,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9218,6 +9242,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-toast": "^1.1.5",
     "@testing-library/user-event": "^14.5.2",
+    "axios": "^1.6.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "date-fns": "^3.2.0",

--- a/src/app/(enter-data)/enter-data/page.tsx
+++ b/src/app/(enter-data)/enter-data/page.tsx
@@ -29,8 +29,8 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
   const redirectToRoute = searchParams.get("redirectTo");
 
   const onSubmit = async (values: formType) => {
-    const formData = cleanFormData(values);
-    setBaseResumeData(JSON.stringify(formData));
+    const formDataString = JSON.stringify(cleanFormData(values));
+    setBaseResumeData(formDataString);
     router.push(redirectToRoute === "base" ? "/generate-resume/base" : "/home");
   };
 

--- a/src/app/(generate-resume)/generate-resume/base/page.tsx
+++ b/src/app/(generate-resume)/generate-resume/base/page.tsx
@@ -12,26 +12,29 @@ import useLocalStorage from "@/lib/hooks/useLocalStorage";
 import { useTimeout } from "@/lib/hooks/useTimeout";
 import { mailToLinks } from "@/lib/utils/string-helpers";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import React, { useEffect, useState } from "react";
 import { useToast } from "@/components/ui/use-toast";
 import { Toaster } from "@/components/ui/toaster";
 import { ToastAction } from "@radix-ui/react-toast";
+import axios from "axios";
 
 type GenerateResumeHomePageProps = {};
 
 const GenerateResumeHomePage: React.FC<GenerateResumeHomePageProps> = () => {
   const [showRedirectModal, setShowRedirectModal] = useState(false);
   const router = useRouter();
-  const [baseResumeData, setBaseResumeData] = useLocalStorage(
-    "base-resume-data-local"
-  );
+  const params = useSearchParams();
+  const [baseResumeData] = useLocalStorage("base-resume-data-local");
+
+  const [downloadData, setDownloadData] = useState<{
+    downloadUrl?: string;
+    state: "neutral" | "in-progress" | "success" | "failure";
+  }>({
+    state: "neutral",
+  });
 
   const { toast: displayToast } = useToast();
-
-  const successfulGeneration = true;
-  const showDisclaimer = true;
-  const showError = true;
 
   // Reditect to enter data route with the correct query params
   // 2 seconds after redirect modal is shown
@@ -42,12 +45,48 @@ const GenerateResumeHomePage: React.FC<GenerateResumeHomePageProps> = () => {
     showRedirectModal ? 2000 : null
   );
 
-  useEffect(() => {
-    if (!!!baseResumeData) {
-      setShowRedirectModal(true);
-    } else {
-      setShowRedirectModal(false);
+  const onGenerateClick = async () => {
+    try {
+      setDownloadData((prev) => ({ ...prev, state: "in-progress" }));
 
+      const downloadState = await axios.post(
+        `${process.env.NEXT_PUBLIC_SITE_URL}/api/data-formatting?action=generateResume${params.get("mockTrue") ? "&mockTrue=true" : ""}`,
+        {
+          resumeData: baseResumeData,
+          id: "base",
+        }
+      );
+
+      if (
+        downloadState.status.toString().startsWith("4") ||
+        downloadState.status.toString().startsWith("5")
+      ) {
+        setDownloadData((prev) => ({ ...prev, state: "failure" }));
+        throw new Error("Error occurred");
+      }
+
+      if (downloadState.status.toString().startsWith("2")) {
+        const downloadUrlRes = await axios(
+          `${process.env.NEXT_PUBLIC_SITE_URL}/api/data-formatting?action=getDownloadLink${params.get("mockTrue") ? "&mockTrue=true" : ""}`
+        );
+
+        if (!downloadUrlRes?.data?.downloadUrl) {
+          setDownloadData((prev) => ({
+            ...prev,
+            downloadUrl: undefined,
+            state: "success",
+          }));
+        } else {
+          setDownloadData((prev) => ({
+            ...prev,
+            downloadUrl: downloadUrlRes.data.downloadUrl,
+            state: "success",
+          }));
+        }
+      }
+    } catch (err) {
+      console.error(err);
+      setDownloadData((prev) => ({ ...prev, state: "failure" }));
       displayToast({
         title: "An error has occurred while generating your resume!",
         description:
@@ -65,6 +104,14 @@ const GenerateResumeHomePage: React.FC<GenerateResumeHomePageProps> = () => {
         ),
         variant: "destructive",
       });
+    }
+  };
+
+  useEffect(() => {
+    if (!!!baseResumeData) {
+      setShowRedirectModal(true);
+    } else {
+      setShowRedirectModal(false);
     }
   }, []);
 
@@ -86,28 +133,50 @@ const GenerateResumeHomePage: React.FC<GenerateResumeHomePageProps> = () => {
               Preview/Update your base data
             </Button>
           </Link>
-          <Button className="max-w-80 w-full">Generate your resume</Button>
-          {successfulGeneration && (
-            <div className="my-8">
-              <h4 className="text-xl font-bold text-center">
-                Your resume has been generated and saved
-              </h4>
-              <p className="text-brand-neutral-11 text-md text-center my-8 mt-4">
-                Your Resume has been generated and saved to your google drive.
-                <br />
-                Click <span className="font-bold">here</span> to download a PDF
-                of your resume.
-              </p>
-            </div>
-          )}
-          {showDisclaimer && (
-            <Alert className="w-fit bg-brand-secondary-blue-2">
-              <AlertDescription>
-                <strong>Note:</strong> Your resume has been saved to your google
-                drive. If you feel the need to edit it, please feel free to do
-                so.
-              </AlertDescription>
-            </Alert>
+          <Button
+            className="max-w-80 w-full"
+            disabled={downloadData.state === "in-progress"}
+            onClick={onGenerateClick}
+          >
+            {downloadData.state === "in-progress"
+              ? "Generating..."
+              : downloadData.state === "success"
+                ? "Re-generate Resume"
+                : "Generate Resume"}
+          </Button>
+          {downloadData.state === "success" && (
+            <>
+              <div className="my-8">
+                <h4 className="text-xl font-bold text-center">
+                  Your resume has been generated and saved
+                </h4>
+                <p className="text-brand-neutral-11 text-md text-center my-8 mt-4">
+                  Your Resume has been generated and saved to your google drive.
+                  <br />
+                  {downloadData.downloadUrl && (
+                    <>
+                      Click{" "}
+                      <a
+                        className="font-bold"
+                        href={downloadData.downloadUrl}
+                        target="_blank"
+                        title="Download your resume"
+                      >
+                        here
+                      </a>{" "}
+                      to download a PDF of your resume.
+                    </>
+                  )}
+                </p>
+              </div>
+              <Alert className="w-fit bg-brand-secondary-blue-2">
+                <AlertDescription>
+                  <strong>Note:</strong> Your resume has been saved to your
+                  google drive. If you feel the need to edit it, please feel
+                  free to do so.
+                </AlertDescription>
+              </Alert>
+            </>
           )}
           <Toaster />
         </section>

--- a/src/app/api/data-formatting/route.ts
+++ b/src/app/api/data-formatting/route.ts
@@ -1,0 +1,127 @@
+import { formSchema } from "@/lib/types/form";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const requestUrl = new URL(req.url);
+
+    // const genResume = requestUrl.searchParams.get("generate-resume");
+    const action = requestUrl.searchParams.get("action");
+    if (!action) {
+      return new NextResponse("Action is Required", {
+        status: 400,
+        statusText: "Bad Request",
+      });
+    }
+    if (action !== "generateResume") {
+      if (!action) {
+        return new NextResponse("Invalid action passed", {
+          status: 400,
+          statusText: "Bad Request",
+        });
+      }
+    }
+
+    const reqBody = await req.json();
+
+    const id = reqBody?.id;
+
+    if (!id) {
+      return new NextResponse("ID is Required", {
+        status: 400,
+        statusText: "Bad Request",
+      });
+    }
+
+    const resumeData = JSON.parse(reqBody?.resumeData || "");
+    if (!resumeData || Object.keys(resumeData).length === 0) {
+      return new NextResponse("Resume Data is required", {
+        status: 400,
+        statusText: "Bad Request",
+      });
+    }
+
+    const mockTrue = requestUrl.searchParams.get("mockTrue");
+    if (mockTrue) {
+      return new NextResponse("The resume has been created", {
+        status: 200,
+        statusText: "Resume Created",
+      });
+    }
+
+    const r = formSchema.safeParse(resumeData);
+    if (!r.success) {
+      console.log(r.error);
+      return new NextResponse("Resume data is not valid", {
+        status: 400,
+        statusText: "Bad Request",
+      });
+    }
+
+    return new NextResponse(
+      "The backend is not supported yet. Please try again later.",
+      {
+        status: 500,
+        statusText: "Internal Server Error",
+      }
+    );
+  } catch (err: unknown) {
+    console.error(err);
+    return new NextResponse(
+      "An error occurred while generating the resume. Please try again later",
+      {
+        status: 500,
+        statusText: "Internal Server Error",
+      }
+    );
+  }
+}
+export async function GET(req: NextRequest) {
+  try {
+    const requestUrl = new URL(req.url);
+
+    const searchParams = requestUrl.searchParams;
+    const getDownloadLink = searchParams.get("action") === "getDownloadLink";
+    const id = searchParams.get("id");
+    const downloadAsPdf = searchParams.get("downloadAsPdf");
+
+    if (getDownloadLink && id) {
+      return new NextResponse(
+        "The backend is not supported yet. Please try again later.",
+        {
+          status: 500,
+          statusText: "Internal Server Error",
+        }
+      );
+    }
+
+    const mockTrue = requestUrl.searchParams.get("mockTrue");
+
+    if (mockTrue === "true") {
+      return new NextResponse(
+        JSON.stringify({
+          downloadUrl:
+            "https://cdn-careerservices.fas.harvard.edu/wp-content/uploads/sites/161/2023/08/College-resume-and-cover-letter-4.pdf",
+        }),
+        {
+          status: 200,
+          statusText: "Success",
+        }
+      );
+    }
+
+    return new NextResponse("Bad Request", {
+      status: 400,
+      statusText: "Bad Request",
+    });
+  } catch (err: unknown) {
+    console.error(err);
+    return new NextResponse(
+      "An error occurred while generating the resume. Please try again later",
+      {
+        status: 500,
+        statusText: "Internal Server Error",
+      }
+    );
+  }
+}

--- a/src/lib/const/form/form-data.ts
+++ b/src/lib/const/form/form-data.ts
@@ -3,7 +3,6 @@ import {
   additionalSectionSchema,
   basicDetailsSectionSchema,
   educationSectionSchema,
-  formType,
   professionalSummarySectionSchema,
   projectsSectionSchema,
   skillsSectionSchema,
@@ -88,13 +87,7 @@ export const DEFAULT_ADDITIONAL_FORM_VALUE: z.infer<
 };
 
 export const DEFAULT_FORM_VALUE = {
-  basicDetails: {
-    type: SECTION.BASIC_DETAILS,
-    sectionTitle: "Basic Details",
-    fields: {
-      name: "",
-    },
-  },
+  basicDetails: DEFAULT_BASIC_DETAILS_FORM_VALUE,
   optionalSections: [
     DEFAULT_PROFESSIONAL_SUMMARY_FORM_VALUE,
     DEFAULT_WORK_EXPERIENCE_FORM_VALUE,

--- a/src/lib/types/form.ts
+++ b/src/lib/types/form.ts
@@ -35,8 +35,8 @@ export const durationFieldSchema = z
   );
 
 export type TDuration = {
-  startDate?: Date | null | undefined;
-  endDate?: Date | null | undefined;
+  startDate?: string | null | undefined;
+  endDate?: string | null | undefined;
   current?: boolean | null | undefined;
 };
 

--- a/src/lib/utils/string-helpers.ts
+++ b/src/lib/utils/string-helpers.ts
@@ -15,7 +15,7 @@ export const mailToLinks = (options?: {
   };
 }) => {
   const {
-    to = "amlanroy2500.resumeCraftBugReport@gmail.com",
+    to = "amlanroy2500+resumeCraftBugReport@gmail.com",
     cc,
     bcc,
     subject = "Bug Report: Resume Craft",
@@ -25,6 +25,7 @@ export const mailToLinks = (options?: {
 
   const body = `${content} ${systemInfo ? "\n System Info:\n \tbrowser: " + systemInfo.browser + "\n \tOS: " + systemInfo.OS + "\n \ttime: " + systemInfo.time + "\n \tdevice:" + systemInfo.device : ""}`;
   return (
-    "mailto:" + `?to=${to}&cc=${cc}&bcc=${bcc}&subject=${subject}&body=${body}`
+    "mailto:" +
+    `?to=${to}${cc ? `&cc=${cc}` : ""}${bcc ? `&bcc=${bcc}` : ""}&subject=${subject}&body=${body}`
   );
 };


### PR DESCRIPTION
Issue: https://github.com/amlan-roy/resume-craft/issues/41
# Summary

## Requirement:

Add the UI support for resume generation

## Changes made:

- Added axios for making api calls
- Refactored some code
- Added states in generate resume page, and displaying error messages/success states etc accordingly
- Added API route (The resume generation api is still in progress)

### Note
If you want the api calls to forcefully pass and return mock data for testing, add  `mockTrue=true` query param in the url and the requests will pass with mock data

## How Has This Been Tested?

Tested the UI locally

### Screenshots / Videos <!-- (Optional but recommended) -->

https://github.com/amlan-roy/resume-craft/assets/59330872/51201ace-dad5-445e-a908-4aa6567be77d

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
