### PR TITLE
Persist form data using local storage

### DIFF
--- a/src/app/(generate-resume)/generate-resume/base/page.tsx
+++ b/src/app/(generate-resume)/generate-resume/base/page.tsx
@@ -8,7 +8,6 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import useLocalStorage from "@/lib/hooks/useLocalStorage";
 import { useTimeout } from "@/lib/hooks/useTimeout";
 import { mailToLinks } from "@/lib/utils/string-helpers";
 import Link from "next/link";
@@ -31,9 +30,6 @@ const GenerateResumeHomePage: React.FC<GenerateResumeHomePageProps> = () => {
   const router = useRouter();
   const params = useSearchParams();
   const [baseResumeData, setBaseResumeData] = useState<null | formType>(null);
-  const [resumeVariantData, setResumeVariantData] = useState<null | formType>(
-    null
-  );
   const [downloadData, setDownloadData] = useState<{
     downloadUrl?: string;
     state: "neutral" | "in-progress" | "success" | "failure";

--- a/src/components/auth/LoadingSkeleton.tsx
+++ b/src/components/auth/LoadingSkeleton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 
 const InputSkeleton = () => {
   return (
@@ -12,12 +13,14 @@ const InputSkeleton = () => {
 
 type LoadingSkeletonProps = {
   inputCount?: number;
+  className?: string;
 };
 const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({
   inputCount = 2,
+  className,
 }) => {
   return (
-    <div className="flex flex-col space-y-3 my-6">
+    <div className={cn(["flex flex-col space-y-3 my-6", className])}>
       {[...Array(inputCount)].map((_, i) => (
         <InputSkeleton key={i} />
       ))}

--- a/src/components/generate-resume/variant/LoadingGenResumeForm.tsx
+++ b/src/components/generate-resume/variant/LoadingGenResumeForm.tsx
@@ -1,0 +1,15 @@
+import LoadingSkeleton from "@/components/auth/LoadingSkeleton";
+import React from "react";
+
+type LoadingGenResumeFormProps = {};
+
+const LoadingGenResumeForm: React.FC<LoadingGenResumeFormProps> = () => {
+  return (
+    <section className="flex flex-col items-center gap-4 w-full">
+      <LoadingSkeleton className="w-full" />
+      <LoadingSkeleton className="w-full" />
+      <LoadingSkeleton className="w-full" />
+    </section>
+  );
+};
+export default LoadingGenResumeForm;

--- a/src/lib/const/generate-resume/generate-resume.ts
+++ b/src/lib/const/generate-resume/generate-resume.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_FORM_DATA = {
+  jobDescription: "",
+  modifiedResumeJSON: "",
+  customResumeName: "",
+};

--- a/src/lib/hooks/useLocalStorage.ts
+++ b/src/lib/hooks/useLocalStorage.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Dispatch, SetStateAction } from "react";
 
 /**
  * A custom hook that returns the value of the data stored in local storage with the provided key
@@ -13,16 +13,11 @@ import { useState, useEffect } from "react";
  * @returns [value, setValue]: The value and the set value for the local storage record
  */
 const useLocalStorage = (key: string, initialValue?: string) => {
-  const [value, setValue] = useState(() => {
-    try {
-      if (typeof window !== "undefined") {
-        const item = window.localStorage.getItem(key);
-        return item ? JSON.parse(item) : initialValue;
-      } else {
-        return initialValue;
-      }
-    } catch (error) {
-      console.error(error);
+  const [value, setValue] = useState<string | undefined>(() => {
+    if (typeof window !== "undefined") {
+      const item = window.localStorage.getItem(key);
+      return item || initialValue;
+    } else {
       return initialValue;
     }
   });
@@ -30,15 +25,17 @@ const useLocalStorage = (key: string, initialValue?: string) => {
   useEffect(() => {
     try {
       if (typeof window !== "undefined") {
-        if (value !== undefined)
-          window.localStorage.setItem(key, JSON.stringify(value));
+        if (value !== undefined) window.localStorage.setItem(key, value);
       }
     } catch (error) {
       console.error(error);
     }
   }, [key, value]);
 
-  return [value, setValue];
+  return [value, setValue] as [
+    string | undefined,
+    Dispatch<SetStateAction<string | undefined>>,
+  ];
 };
 
 export default useLocalStorage;


### PR DESCRIPTION
Issue: https://github.com/amlan-roy/resume-craft/issues/64

<!-- NOTE: Each PR should be associated with an issue. Create an issue if it does not already exists -->

## Summary
The "Generate Resume" page form data is stored in local storage every time any input is updated in the form.

## How Has This Been Tested?

Tested the UI locally.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
