### PR TITLE
fix: fix the loading state of the auth flow

### DIFF
--- a/src/components/auth/login/LoginForm.tsx
+++ b/src/components/auth/login/LoginForm.tsx
@@ -141,7 +141,9 @@ const LoginForm: React.FC<LoginFormProps> = ({ hideForm }) => {
                   <Button
                     className="w-full max-w-72 text-md py-6"
                     type="submit"
-                    disabled={authState === "loading"}
+                    disabled={
+                      authState === "loading" || authState === "authenticated"
+                    }
                   >
                     Login
                   </Button>
@@ -152,7 +154,9 @@ const LoginForm: React.FC<LoginFormProps> = ({ hideForm }) => {
           <p className="my-4 text-center text-brand-neutral-7">OR</p>
           <div className="flex justify-center">
             <GoogleJoinButton
-              isAuthInProgress={authState === "loading"}
+              isAuthInProgress={
+                authState === "loading" || authState === "authenticated"
+              }
               loginUsingGoogle={googleAuth}
             />
           </div>

--- a/src/components/auth/signup/SignupForm.tsx
+++ b/src/components/auth/signup/SignupForm.tsx
@@ -143,7 +143,9 @@ const SignupForm: React.FC<SignupFormProps> = ({ hideForm }) => {
                 <Button
                   className="w-full max-w-72 text-md py-6"
                   type="submit"
-                  disabled={authState === "loading"}
+                  disabled={
+                    authState === "loading" || authState === "authenticated"
+                  }
                 >
                   Signup
                 </Button>
@@ -155,7 +157,9 @@ const SignupForm: React.FC<SignupFormProps> = ({ hideForm }) => {
       <p className="my-4 text-center text-brand-neutral-7">OR</p>
       <div className="flex justify-center">
         <GoogleJoinButton
-          isAuthInProgress={authState === "loading"}
+          isAuthInProgress={
+            authState === "loading" || authState === "authenticated"
+          }
           loginUsingGoogle={signupWithGoogle}
         />
       </div>


### PR DESCRIPTION
Issue: https://github.com/amlan-roy/resume-craft/issues/102

## Summary

- The loading of login/auth stops after the auth, and there is a small delay before tansition to the home page.
- Fixed the flow to keep the loading state when authState is loading or authenticated to mitigate this extra delay

## Testing done

- Tested the UI
- Existing tests pass
- Will need to add more tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
