### PR TITLE
Add delete resume confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "tailwind-merge": "^2.2.0",
         "tailwindcss-animate": "^1.0.7",
         "ts-node": "^10.9.2",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@babel/plugin-syntax-jsx": "^7.23.3",
@@ -12522,6 +12523,14 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -12984,6 +12993,33 @@
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.2.tgz",
+      "integrity": "sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "ts-node": "^10.9.2",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@babel/plugin-syntax-jsx": "^7.23.3",

--- a/src/app/(my-resumes)/my-resumes/page.tsx
+++ b/src/app/(my-resumes)/my-resumes/page.tsx
@@ -57,7 +57,6 @@ const MyResumesPage: React.FC<MyResumesPageProps> = () => {
       description: errorMessage,
       variant: "destructive",
     });
-    console.error(e);
   };
 
   const resetDialogState = () => {
@@ -135,6 +134,7 @@ const MyResumesPage: React.FC<MyResumesPageProps> = () => {
                           e.message ||
                           "An error occurred while downloading the resume!";
                         displayErrorToast(errorMessage);
+                        console.error(e);
                         dialogState.resolve?.(false);
                         resetDialogState();
                       },
@@ -167,6 +167,7 @@ const MyResumesPage: React.FC<MyResumesPageProps> = () => {
                           e.message ||
                           "An error occurred while deleting the resume!";
                         displayErrorToast(errorMessage);
+                        console.error(e);
                         dialogState.resolve?.(false);
                         resetDialogState();
                       },
@@ -204,6 +205,7 @@ const MyResumesPage: React.FC<MyResumesPageProps> = () => {
                                   e.message ||
                                   "An error occurred while downloading the resume!";
                                 displayErrorToast(errorMessage);
+                                console.error(e);
                                 dialogState.resolve?.(false);
                                 resetDialogState();
                               },
@@ -247,6 +249,7 @@ const MyResumesPage: React.FC<MyResumesPageProps> = () => {
                                   e.message ||
                                   "An error occurred while deleting the resume!";
                                 displayErrorToast(errorMessage);
+                                console.error(e);
                                 dialogState.resolve?.(false);
                                 resetDialogState();
                               },


### PR DESCRIPTION
Issue:

<!-- NOTE: Each PR should be associated with an issue. Create an issue if it does not already exists -->

## Summary

- Added a confirmation dialog for deleting the resumes

**Additional Changes:**
- Added zustand dependency. (Will add it later for state management. Had initally planned to use it here itself. But normal state did the job here. Keeping the dependency bump here)
- Added loading text in the my resume page

## Testing done

Locally tested
Existing tests pass