### PR TITLE
use context to declutter the popup modal logic in dynamic form

### DIFF
--- a/src/app/(enter-data)/enter-data/page.tsx
+++ b/src/app/(enter-data)/enter-data/page.tsx
@@ -76,7 +76,7 @@ const EnterDataPage: React.FC<EnterDataPageProps> = () => {
           });
       }
     });
-  }, []);
+  });
 
   return (
     <>

--- a/src/app/(generate-resume)/generate-resume/[slug]/page.tsx
+++ b/src/app/(generate-resume)/generate-resume/[slug]/page.tsx
@@ -103,7 +103,7 @@ const GenerateVariantHomePage: React.FC<GenerateVariantHomePageProps> = ({
         });
       }
     });
-  }, []);
+  });
 
   React.useEffect(() => {
     const subscription = watch((value) => {

--- a/src/components/global/AuthenticatedHeader.tsx
+++ b/src/components/global/AuthenticatedHeader.tsx
@@ -55,7 +55,7 @@ const AuthenticatedHeader: React.FC<AuthenticatedHeaderProps> = ({
 
   useEffect(() => {
     verifyAndSetEmailVerified(isEmailVerified);
-  }, [verifyAndSetEmailVerified]);
+  });
 
   const { toast: displayToast } = useToast();
 

--- a/src/components/global/form/form-sections/Additional.tsx
+++ b/src/components/global/form/form-sections/Additional.tsx
@@ -1,12 +1,15 @@
-import React, { useState } from "react";
+"use client";
+
+import React, { useContext } from "react";
 import { Trash2Icon } from "lucide-react";
 import { useFormContext } from "react-hook-form";
 import { SECTION, formType } from "@/lib/types/form";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import HiddenInput from "@/components/global/form/form-inputs/HiddenInput";
 import TextInput from "@/components/global/form/form-inputs/TextInput";
-import PopupDialog from "../../dialog/PopupDialog";
+import { ModalStateContext } from "../modal-state-provider";
 
 type AdditionalProps = {
   deleteSection: () => void;
@@ -31,100 +34,99 @@ const Additional: React.FC<AdditionalProps> = ({ deleteSection, index }) => {
     formState: { errors },
   } = useFormContext<formType>();
 
-  const [modalState, setModalState] = useState<{
-    open: boolean;
-  }>({
-    open: false,
-  });
-  return (
-    <>
-      <Card
-        data-card-type={SECTION.ADDITIONAL}
-        className="bg-brand-secondary-blue-1"
-      >
-        <HiddenInput
-          fieldName={
-            index !== undefined && index !== null
-              ? `${fieldName}.${index}.type`
-              : undefined
-          }
-          value={SECTION.ADDITIONAL}
-          register={register}
-        />
-        <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
-          <CardTitle className="w-full max-w-[75%]">
-            <Label>Section Title:</Label>
-            <TextInput
-              fieldName={
-                index !== undefined && index !== null
-                  ? `${fieldName}.${index}.sectionTitle`
-                  : undefined
-              }
-              register={register}
-              inputClassName="text-xl md:text-2xl py-6"
-              placeholder="Section title"
-              errorMessage={
-                index !== undefined
-                  ? errors?.[fieldName]?.[index]?.sectionTitle?.message
-                  : undefined
-              }
-            />
-          </CardTitle>
+  const modalStateContext = useContext(ModalStateContext);
+  if (!modalStateContext) {
+    throw new Error(
+      "Additional section component must be used within a DynamicForm component"
+    );
+  }
 
-          <button
-            className="ml-auto"
-            onClick={() => {
-              setModalState({
-                open: true,
-              });
-            }}
-            type="button"
-            data-testid="form-sections__delete-icon"
-            title="Delete this section"
-          >
-            <Trash2Icon />
-          </button>
-        </CardHeader>
-        <CardContent className="flex flex-wrap w-full">
-          <Label>Details:</Label>
+  const handleSectionDelete = () => {
+    modalStateContext.setModalState({
+      title: TEXT_COPIES.MODAL.title,
+      message: TEXT_COPIES.MODAL.description,
+      isOpen: true,
+      confirmText: TEXT_COPIES.MODAL.confirmText,
+      cancelText: TEXT_COPIES.MODAL.cancelText,
+      onConfirm: () => {
+        deleteSection?.();
+        modalStateContext.setModalState({ isOpen: false });
+      },
+      onCancel: () => {
+        modalStateContext.setModalState({ isOpen: false });
+      },
+    });
+  };
+
+  return (
+    <Card
+      data-card-type={SECTION.ADDITIONAL}
+      className="bg-brand-secondary-blue-1"
+    >
+      <HiddenInput
+        fieldName={
+          index !== undefined && index !== null
+            ? `${fieldName}.${index}.type`
+            : undefined
+        }
+        value={SECTION.ADDITIONAL}
+        register={register}
+      />
+      <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
+        <CardTitle className="w-full max-w-[75%]">
+          <Label>Section Title:</Label>
           <TextInput
             fieldName={
               index !== undefined && index !== null
-                ? `${fieldName}.${index}.fields.value`
+                ? `${fieldName}.${index}.sectionTitle`
                 : undefined
             }
             register={register}
-            multiline
-            className="w-full"
-            placeholder={
-              "- Did ABC to achieve DEF\n- Won XYZ competition\n- Have a rating of 100 in PQR"
-            }
+            inputClassName="text-xl md:text-2xl py-6"
+            placeholder="Section title"
             errorMessage={
               index !== undefined
-                ? // todo: fix this later
-                  // @ts-expect-error: some ts error
-                  errors?.[fieldName]?.[index]?.fields?.value?.message
+                ? errors?.[fieldName]?.[index]?.sectionTitle?.message
                 : undefined
             }
           />
-        </CardContent>
-      </Card>
+        </CardTitle>
 
-      <PopupDialog
-        open={modalState.open}
-        onCancel={() => {
-          setModalState({ open: false });
-        }}
-        onConfirm={() => {
-          deleteSection?.();
-          setModalState({ open: false });
-        }}
-        title={TEXT_COPIES.MODAL.title}
-        description={TEXT_COPIES.MODAL.description}
-        cancelText={TEXT_COPIES.MODAL.cancelText}
-        confirmText={TEXT_COPIES.MODAL.confirmText}
-      />
-    </>
+        <Button
+          className="ml-auto"
+          onClick={handleSectionDelete}
+          type="button"
+          variant={"ghost"}
+          data-testid="form-sections__delete-icon"
+          title="Delete this section"
+        >
+          <Trash2Icon />
+        </Button>
+      </CardHeader>
+      <CardContent className="flex flex-wrap w-full">
+        <Label>Details:</Label>
+        <TextInput
+          fieldName={
+            index !== undefined && index !== null
+              ? `${fieldName}.${index}.fields.value`
+              : undefined
+          }
+          register={register}
+          multiline
+          className="w-full"
+          placeholder={
+            "- Did ABC to achieve DEF\n- Won XYZ competition\n- Have a rating of 100 in PQR"
+          }
+          errorMessage={
+            index !== undefined
+              ? // todo: fix this later
+                // @ts-expect-error: some ts error
+                errors?.[fieldName]?.[index]?.fields?.value?.message
+              : undefined
+          }
+        />
+      </CardContent>
+    </Card>
   );
 };
 export default Additional;

--- a/src/components/global/form/form-sections/Education.tsx
+++ b/src/components/global/form/form-sections/Education.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext } from "react";
 import { PlusCircleIcon, Trash2Icon } from "lucide-react";
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
@@ -12,10 +12,10 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
+import DurationInput from "@/components/global/form/form-inputs/DurationInput";
 import HiddenInput from "@/components/global/form/form-inputs/HiddenInput";
 import TextInput from "@/components/global/form/form-inputs/TextInput";
-import PopupDialog from "../../dialog/PopupDialog";
-import DurationInput from "../form-inputs/DurationInput";
+import { ModalStateContext } from "@/components/global/form/modal-state-provider";
 
 const fieldName = "optionalSections";
 
@@ -64,216 +64,211 @@ const Education: React.FC<EducationProps> = ({
   updateFields,
 }) => {
   const { register } = useFormContext<formType>();
-  const [modalState, setModalState] = useState<{
-    open: boolean;
-    type: "DELETE_SECTION" | "DELETE_SUBSECTION" | "DELETE_LAST_SUBSECTION";
-    subsectionToDeleteIndex?: number;
-  }>({
-    open: false,
-    type: "DELETE_SECTION",
-  });
+
+  const modalStateContext = useContext(ModalStateContext);
+  if (!modalStateContext) {
+    throw new Error(
+      "Additional section component must be used within a DynamicForm component"
+    );
+  }
+
+  const handleDelete = (
+    subSectionIndex?: number,
+    isLastSubsection?: boolean
+  ) => {
+    const modalTextKey = subSectionIndex
+      ? isLastSubsection
+        ? "DELETE_LAST_SUBSECTION"
+        : "DELETE_SUBSECTION"
+      : "DELETE_SECTION";
+
+    const onConfirm = () => {
+      if (subSectionIndex && !isLastSubsection) {
+        updateFields?.(false, subSectionIndex);
+      } else {
+        deleteSection?.();
+      }
+      modalStateContext.setModalState({ isOpen: false });
+    };
+
+    const onCancel = () => {
+      modalStateContext.setModalState({ isOpen: false });
+    };
+
+    modalStateContext.setModalState({
+      title: TEXT_COPIES.MODAL?.[modalTextKey].title,
+      message: TEXT_COPIES.MODAL?.[modalTextKey].description,
+      isOpen: true,
+      confirmText: TEXT_COPIES.MODAL?.[modalTextKey].confirmText,
+      cancelText: TEXT_COPIES.MODAL?.[modalTextKey].cancelText,
+      onConfirm,
+      onCancel,
+    });
+  };
 
   return (
-    <>
-      <Card
-        data-card-type={SECTION.EDUCATION}
-        className="bg-brand-secondary-blue-1"
-      >
-        <HiddenInput
-          fieldName={
-            fieldName && (index !== undefined || index !== null)
-              ? `${fieldName}.${index}.type`
-              : undefined
-          }
-          value={SECTION.EDUCATION}
-          register={register}
-        />
-        <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
-          <CardTitle className="w-full max-w-[75%]">
-            <Label>Section Title:</Label>
-            <TextInput
-              fieldName={
-                fieldName && (index !== undefined || index !== null)
-                  ? `${fieldName}.${index}.sectionTitle`
-                  : undefined
-              }
-              register={register}
-              inputClassName="text-xl md:text-2xl py-6"
-              placeholder="Section title"
-              errorMessage={fieldErrors?.sectionTitle?.message}
-            />
-          </CardTitle>
-
-          <Button
-            className="ml-auto"
-            onClick={() => {
-              setModalState({
-                open: true,
-                type: "DELETE_SECTION",
-              });
-            }}
-            type="button"
-            variant={"ghost"}
-            title="Delete this section"
-          >
-            <Trash2Icon />
-          </Button>
-        </CardHeader>
-        <CardContent className="flex flex-wrap w-full gap-5">
-          {fields?.map((field, subSectionIndex) => (
-            <Card
-              className="w-full"
-              key={`work-experience-${index}-subsection-${subSectionIndex}`}
-            >
-              <CardHeader className="items-end">
-                <Button
-                  type="button"
-                  variant={"ghost"}
-                  className="w-fit"
-                  onClick={() =>
-                    setModalState({
-                      open: true,
-                      type:
-                        fields.length > 1
-                          ? "DELETE_SUBSECTION"
-                          : "DELETE_LAST_SUBSECTION",
-                      subsectionToDeleteIndex: subSectionIndex,
-                    })
-                  }
-                  title="Delete this sub-section"
-                >
-                  <Trash2Icon className=" w-5 h-5" />
-                </Button>
-              </CardHeader>
-              <CardContent className="flex flex-row flex-wrap gap-10">
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].universityName`
-                      : undefined
-                  }
-                  register={register}
-                  label="University Name"
-                  autoComplete="organization-title"
-                  placeholder="College of Delusion and Anxiety"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.universityName
-                      ?.message
-                  }
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].degreeName`
-                      : undefined
-                  }
-                  register={register}
-                  label="Degree Name"
-                  placeholder="Bachelors of Exestential Crisis"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.degreeName?.message
-                  }
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].majorName`
-                      : undefined
-                  }
-                  register={register}
-                  label="Major Name"
-                  placeholder="Panic Attack"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.majorName?.message
-                  }
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].grade`
-                      : undefined
-                  }
-                  register={register}
-                  label="Grade"
-                  placeholder="9.9/10"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.grade?.message
-                  }
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].location`
-                      : undefined
-                  }
-                  register={register}
-                  label="Location"
-                  autoComplete="address-level1"
-                  placeholder="Powder Gully, Mumbai"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.location?.message
-                  }
-                />
-
-                <DurationInput
-                  fieldName={`${fieldName}.[${index}].fields.[${subSectionIndex}].duration`}
-                  subFieldNames={{
-                    startDate: "startDate",
-                    endDate: "endDate",
-                    current: "current",
-                  }}
-                  labels={{
-                    startDate: "Start Date",
-                    endDate: "End Date",
-                    current: "I an currently Studying here",
-                  }}
-                />
-              </CardContent>
-            </Card>
-          ))}
-        </CardContent>
-        <CardFooter>
-          <Button
-            type="button"
-            variant={"outline"}
-            onClick={() => updateFields?.(true)}
-            className="py-6"
-          >
-            <PlusCircleIcon className="w-8 h-8 mr-4" />
-            <span className="text-base">Add Sub Section</span>
-          </Button>
-        </CardFooter>
-      </Card>
-      <PopupDialog
-        open={modalState.open}
-        onCancel={() => {
-          setModalState((prev) => ({
-            ...prev,
-            open: false,
-            subsectionToDeleteIndex: undefined,
-          }));
-        }}
-        onConfirm={() => {
-          ["DELETE_SECTION", "DELETE_LAST_SUBSECTION"].includes(modalState.type)
-            ? deleteSection?.()
-            : updateFields?.(false, modalState.subsectionToDeleteIndex);
-          setModalState((prev) => ({
-            ...prev,
-            open: false,
-            subsectionToDeleteIndex: undefined,
-          }));
-        }}
-        title={TEXT_COPIES.MODAL?.[modalState.type].title}
-        description={TEXT_COPIES.MODAL?.[modalState.type].description}
-        cancelText={TEXT_COPIES.MODAL?.[modalState.type].cancelText}
-        confirmText={TEXT_COPIES.MODAL?.[modalState.type].confirmText}
+    <Card
+      data-card-type={SECTION.EDUCATION}
+      className="bg-brand-secondary-blue-1"
+    >
+      <HiddenInput
+        fieldName={
+          fieldName && (index !== undefined || index !== null)
+            ? `${fieldName}.${index}.type`
+            : undefined
+        }
+        value={SECTION.EDUCATION}
+        register={register}
       />
-    </>
+      <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
+        <CardTitle className="w-full max-w-[75%]">
+          <Label>Section Title:</Label>
+          <TextInput
+            fieldName={
+              fieldName && (index !== undefined || index !== null)
+                ? `${fieldName}.${index}.sectionTitle`
+                : undefined
+            }
+            register={register}
+            inputClassName="text-xl md:text-2xl py-6"
+            placeholder="Section title"
+            errorMessage={fieldErrors?.sectionTitle?.message}
+          />
+        </CardTitle>
+
+        <Button
+          className="ml-auto"
+          onClick={() => handleDelete()}
+          type="button"
+          variant={"ghost"}
+          title="Delete this section"
+        >
+          <Trash2Icon />
+        </Button>
+      </CardHeader>
+      <CardContent className="flex flex-wrap w-full gap-5">
+        {fields?.map((field, subSectionIndex) => (
+          <Card
+            className="w-full"
+            key={`work-experience-${index}-subsection-${subSectionIndex}`}
+          >
+            <CardHeader className="items-end">
+              <Button
+                type="button"
+                variant={"ghost"}
+                className="w-fit"
+                onClick={() =>
+                  handleDelete(subSectionIndex, fields?.length === 1)
+                }
+                title="Delete this sub-section"
+              >
+                <Trash2Icon className=" w-5 h-5" />
+              </Button>
+            </CardHeader>
+            <CardContent className="flex flex-row flex-wrap gap-10">
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].universityName`
+                    : undefined
+                }
+                register={register}
+                label="University Name"
+                autoComplete="organization-title"
+                placeholder="College of Delusion and Anxiety"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.universityName
+                    ?.message
+                }
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].degreeName`
+                    : undefined
+                }
+                register={register}
+                label="Degree Name"
+                placeholder="Bachelors of Exestential Crisis"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.degreeName?.message
+                }
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].majorName`
+                    : undefined
+                }
+                register={register}
+                label="Major Name"
+                placeholder="Panic Attack"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.majorName?.message
+                }
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].grade`
+                    : undefined
+                }
+                register={register}
+                label="Grade"
+                placeholder="9.9/10"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.grade?.message
+                }
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].location`
+                    : undefined
+                }
+                register={register}
+                label="Location"
+                autoComplete="address-level1"
+                placeholder="Powder Gully, Mumbai"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.location?.message
+                }
+              />
+
+              <DurationInput
+                fieldName={`${fieldName}.[${index}].fields.[${subSectionIndex}].duration`}
+                subFieldNames={{
+                  startDate: "startDate",
+                  endDate: "endDate",
+                  current: "current",
+                }}
+                labels={{
+                  startDate: "Start Date",
+                  endDate: "End Date",
+                  current: "I an currently Studying here",
+                }}
+              />
+            </CardContent>
+          </Card>
+        ))}
+      </CardContent>
+      <CardFooter>
+        <Button
+          type="button"
+          variant={"outline"}
+          onClick={() => updateFields?.(true)}
+          className="py-6"
+        >
+          <PlusCircleIcon className="w-8 h-8 mr-4" />
+          <span className="text-base">Add Sub Section</span>
+        </Button>
+      </CardFooter>
+    </Card>
   );
 };
 export default Education;

--- a/src/components/global/form/form-sections/Education.tsx
+++ b/src/components/global/form/form-sections/Education.tsx
@@ -68,7 +68,7 @@ const Education: React.FC<EducationProps> = ({
   const modalStateContext = useContext(ModalStateContext);
   if (!modalStateContext) {
     throw new Error(
-      "Additional section component must be used within a DynamicForm component"
+      "Education section component must be used within a DynamicForm component"
     );
   }
 

--- a/src/components/global/form/form-sections/ProfessionalSummary.tsx
+++ b/src/components/global/form/form-sections/ProfessionalSummary.tsx
@@ -37,7 +37,7 @@ const ProfessionalSummary: React.FC<ProfessionalSummaryProps> = ({
   const modalStateContext = useContext(ModalStateContext);
   if (!modalStateContext) {
     throw new Error(
-      "Additional section component must be used within a DynamicForm component"
+      "ProfessionalSummary section component must be used within a DynamicForm component"
     );
   }
 

--- a/src/components/global/form/form-sections/ProfessionalSummary.tsx
+++ b/src/components/global/form/form-sections/ProfessionalSummary.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from "react";
+import React, { useContext } from "react";
 import { Trash2Icon } from "lucide-react";
 import { useFormContext } from "react-hook-form";
 import { SECTION, formType } from "@/lib/types/form";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
-import PopupDialog from "@/components/global/dialog/PopupDialog";
 import HiddenInput from "@/components/global/form/form-inputs/HiddenInput";
 import TextInput from "@/components/global/form/form-inputs/TextInput";
+import { ModalStateContext } from "@/components/global/form/modal-state-provider";
 
 type ProfessionalSummaryProps = {
   deleteSection: () => void;
@@ -34,99 +34,97 @@ const ProfessionalSummary: React.FC<ProfessionalSummaryProps> = ({
     formState: { errors },
   } = useFormContext<formType>();
 
-  const [modalState, setModalState] = useState<{
-    open: boolean;
-  }>({
-    open: false,
-  });
-  return (
-    <>
-      <Card
-        data-testid="form-sections__professional-summary"
-        data-card-type={SECTION.PROFESSIONAL_SUMMARY}
-        className="bg-brand-secondary-blue-1"
-      >
-        <HiddenInput
-          fieldName={
-            index !== undefined && index !== null
-              ? `${fieldName}.${index}.type`
-              : undefined
-          }
-          value={SECTION.PROFESSIONAL_SUMMARY}
-          register={register}
-        />
-        <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
-          <CardTitle className="w-full max-w-[75%]">
-            <Label>Section Title:</Label>
-            <TextInput
-              fieldName={
-                index !== undefined && index !== null
-                  ? `${fieldName}.${index}.sectionTitle`
-                  : undefined
-              }
-              register={register}
-              inputClassName="text-xl md:text-2xl py-6"
-              placeholder="Section title"
-              errorMessage={
-                index !== undefined
-                  ? errors?.[fieldName]?.[index]?.sectionTitle?.message
-                  : undefined
-              }
-            />
-          </CardTitle>
+  const modalStateContext = useContext(ModalStateContext);
+  if (!modalStateContext) {
+    throw new Error(
+      "Additional section component must be used within a DynamicForm component"
+    );
+  }
 
-          <button
-            className="ml-auto"
-            onClick={() => {
-              setModalState({
-                open: true,
-              });
-            }}
-            type="button"
-            data-testid="form-sections__delete-icon"
-            title="Delete section"
-          >
-            <Trash2Icon />
-          </button>
-        </CardHeader>
-        <CardContent className="flex flex-wrap w-full">
-          <Label>Details:</Label>
+  const handleSectionDelete = () => {
+    modalStateContext.setModalState({
+      title: TEXT_COPIES.MODAL.title,
+      message: TEXT_COPIES.MODAL.description,
+      isOpen: true,
+      confirmText: TEXT_COPIES.MODAL.confirmText,
+      cancelText: TEXT_COPIES.MODAL.cancelText,
+      onConfirm: () => {
+        deleteSection?.();
+        modalStateContext.setModalState({ isOpen: false });
+      },
+      onCancel: () => {
+        modalStateContext.setModalState({ isOpen: false });
+      },
+    });
+  };
+
+  return (
+    <Card
+      data-testid="form-sections__professional-summary"
+      data-card-type={SECTION.PROFESSIONAL_SUMMARY}
+      className="bg-brand-secondary-blue-1"
+    >
+      <HiddenInput
+        fieldName={
+          index !== undefined && index !== null
+            ? `${fieldName}.${index}.type`
+            : undefined
+        }
+        value={SECTION.PROFESSIONAL_SUMMARY}
+        register={register}
+      />
+      <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
+        <CardTitle className="w-full max-w-[75%]">
+          <Label>Section Title:</Label>
           <TextInput
             fieldName={
               index !== undefined && index !== null
-                ? `${fieldName}.${index}.fields.value`
+                ? `${fieldName}.${index}.sectionTitle`
                 : undefined
             }
             register={register}
-            multiline
-            className="w-full"
-            placeholder="Galactic Theorist with decades of experience, specializing in unraveling the fabric of the cosmos and visiting islands. Proficient in quantum mechanics, general relativity, and little people. Experienced in solving complex quadratic equations."
+            inputClassName="text-xl md:text-2xl py-6"
+            placeholder="Section title"
             errorMessage={
               index !== undefined
-                ? // todo: fix this later
-                  // @ts-expect-error: some ts error
-                  errors?.[fieldName]?.[index]?.fields?.value?.message
+                ? errors?.[fieldName]?.[index]?.sectionTitle?.message
                 : undefined
             }
           />
-        </CardContent>
-      </Card>
+        </CardTitle>
 
-      <PopupDialog
-        open={modalState.open}
-        onCancel={() => {
-          setModalState({ open: false });
-        }}
-        onConfirm={() => {
-          deleteSection?.();
-          setModalState({ open: false });
-        }}
-        title={TEXT_COPIES.MODAL.title}
-        description={TEXT_COPIES.MODAL.description}
-        cancelText={TEXT_COPIES.MODAL.cancelText}
-        confirmText={TEXT_COPIES.MODAL.confirmText}
-      />
-    </>
+        <button
+          className="ml-auto"
+          onClick={handleSectionDelete}
+          type="button"
+          data-testid="form-sections__delete-icon"
+          title="Delete section"
+        >
+          <Trash2Icon />
+        </button>
+      </CardHeader>
+      <CardContent className="flex flex-wrap w-full">
+        <Label>Details:</Label>
+        <TextInput
+          fieldName={
+            index !== undefined && index !== null
+              ? `${fieldName}.${index}.fields.value`
+              : undefined
+          }
+          register={register}
+          multiline
+          className="w-full"
+          placeholder="Galactic Theorist with decades of experience, specializing in unraveling the fabric of the cosmos and visiting islands. Proficient in quantum mechanics, general relativity, and little people. Experienced in solving complex quadratic equations."
+          errorMessage={
+            index !== undefined
+              ? // todo: fix this later
+                // @ts-expect-error: some ts error
+                errors?.[fieldName]?.[index]?.fields?.value?.message
+              : undefined
+          }
+        />
+      </CardContent>
+    </Card>
   );
 };
 export default ProfessionalSummary;

--- a/src/components/global/form/form-sections/Projects.tsx
+++ b/src/components/global/form/form-sections/Projects.tsx
@@ -68,7 +68,7 @@ const Projects: React.FC<ProjectsProps> = ({
   const modalStateContext = useContext(ModalStateContext);
   if (!modalStateContext) {
     throw new Error(
-      "Additional section component must be used within a DynamicForm component"
+      "Projects section component must be used within a DynamicForm component"
     );
   }
 

--- a/src/components/global/form/form-sections/Projects.tsx
+++ b/src/components/global/form/form-sections/Projects.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext } from "react";
 import { PlusCircleIcon, Trash2Icon } from "lucide-react";
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
@@ -12,10 +12,10 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
+import DurationInput from "@/components/global/form/form-inputs/DurationInput";
 import HiddenInput from "@/components/global/form/form-inputs/HiddenInput";
 import TextInput from "@/components/global/form/form-inputs/TextInput";
-import PopupDialog from "../../dialog/PopupDialog";
-import DurationInput from "../form-inputs/DurationInput";
+import { ModalStateContext } from "@/components/global/form/modal-state-provider";
 
 const fieldName = "optionalSections";
 
@@ -64,220 +64,216 @@ const Projects: React.FC<ProjectsProps> = ({
   updateFields,
 }) => {
   const { register } = useFormContext<formType>();
-  const [modalState, setModalState] = useState<{
-    open: boolean;
-    type: "DELETE_SECTION" | "DELETE_SUBSECTION" | "DELETE_LAST_SUBSECTION";
-    subsectionToDeleteIndex?: number;
-  }>({
-    open: false,
-    type: "DELETE_SECTION",
-  });
+
+  const modalStateContext = useContext(ModalStateContext);
+  if (!modalStateContext) {
+    throw new Error(
+      "Additional section component must be used within a DynamicForm component"
+    );
+  }
+
+  const handleDelete = (
+    subSectionIndex?: number,
+    isLastSubsection?: boolean
+  ) => {
+    const modalTextKey = subSectionIndex
+      ? isLastSubsection
+        ? "DELETE_LAST_SUBSECTION"
+        : "DELETE_SUBSECTION"
+      : "DELETE_SECTION";
+
+    const onConfirm = () => {
+      if (subSectionIndex && !isLastSubsection) {
+        updateFields?.(false, subSectionIndex);
+      } else {
+        deleteSection?.();
+      }
+      modalStateContext.setModalState({ isOpen: false });
+    };
+
+    const onCancel = () => {
+      modalStateContext.setModalState({ isOpen: false });
+    };
+
+    modalStateContext.setModalState({
+      title: TEXT_COPIES.MODAL?.[modalTextKey].title,
+      message: TEXT_COPIES.MODAL?.[modalTextKey].description,
+      isOpen: true,
+      confirmText: TEXT_COPIES.MODAL?.[modalTextKey].confirmText,
+      cancelText: TEXT_COPIES.MODAL?.[modalTextKey].cancelText,
+      onConfirm,
+      onCancel,
+    });
+  };
 
   return (
-    <>
-      <Card
-        data-card-type={SECTION.PROJECTS}
-        className="bg-brand-secondary-blue-1"
-      >
-        <HiddenInput
-          fieldName={
-            fieldName && (index !== undefined || index !== null)
-              ? `${fieldName}.${index}.type`
-              : undefined
-          }
-          value={SECTION.PROJECTS}
-          register={register}
-        />
-        <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
-          <CardTitle className="w-full max-w-[75%]">
-            <Label>Section Title:</Label>
-            <TextInput
-              fieldName={
-                fieldName && (index !== undefined || index !== null)
-                  ? `${fieldName}.${index}.sectionTitle`
-                  : undefined
-              }
-              register={register}
-              inputClassName="text-xl md:text-2xl py-6"
-              placeholder="Relevant Projects"
-              errorMessage={fieldErrors?.sectionTitle?.message}
-            />
-          </CardTitle>
-
-          <Button
-            className="ml-auto"
-            onClick={() => {
-              setModalState({
-                open: true,
-                type: "DELETE_SECTION",
-              });
-            }}
-            type="button"
-            variant={"ghost"}
-            title="Delete this section"
-          >
-            <Trash2Icon />
-          </Button>
-        </CardHeader>
-        <CardContent className="flex flex-wrap w-full gap-5">
-          {fields?.map((field, subSectionIndex) => (
-            <Card
-              className="w-full"
-              key={`projects-${index}-subsection-${subSectionIndex}`}
-            >
-              <CardHeader className="items-end">
-                <Button
-                  type="button"
-                  variant={"ghost"}
-                  className="w-fit"
-                  onClick={() =>
-                    setModalState({
-                      open: true,
-                      type:
-                        fields.length > 1
-                          ? "DELETE_SUBSECTION"
-                          : "DELETE_LAST_SUBSECTION",
-                      subsectionToDeleteIndex: subSectionIndex,
-                    })
-                  }
-                  title="Delete this sub-section"
-                >
-                  <Trash2Icon className=" w-5 h-5" />
-                </Button>
-              </CardHeader>
-              <CardContent className="flex flex-row flex-wrap gap-10">
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].projectTitle`
-                      : undefined
-                  }
-                  register={register}
-                  label="Project Title"
-                  placeholder="Jalebi Maker"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.projectTitle
-                      ?.message
-                  }
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].projectSubtitle`
-                      : undefined
-                  }
-                  label="Project Subtitle"
-                  register={register}
-                  placeholder="Food Tech, Electronics, Automation"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.projectSubtitle
-                      ?.message
-                  }
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].projectUrl`
-                      : undefined
-                  }
-                  register={register}
-                  label="Project Url"
-                  autoComplete="url"
-                  placeholder="www.jalebi-maker.com"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.projectUrl?.message
-                  }
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].associatedWith`
-                      : undefined
-                  }
-                  register={register}
-                  label="Associated with"
-                  autoComplete="organization"
-                  placeholder="Gada Electronics"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.associatedWith
-                      ?.message
-                  }
-                />
-                <DurationInput
-                  fieldName={`${fieldName}.[${index}].fields.[${subSectionIndex}].duration`}
-                  subFieldNames={{
-                    startDate: "startDate",
-                    endDate: "endDate",
-                    current: "current",
-                  }}
-                  labels={{
-                    startDate: "Start Date",
-                    endDate: "End Date",
-                    current: "I am currently working on this project",
-                  }}
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].details`
-                      : undefined
-                  }
-                  label="Description"
-                  multiline
-                  register={register}
-                  placeholder={
-                    '- Created Jalebi Maker Machine- Goes well with "Chi Piyo, Biscuit Khao"\n-Got Funding from Gada Electronics'
-                  }
-                  className="w-full"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.details?.message
-                  }
-                />
-              </CardContent>
-            </Card>
-          ))}
-        </CardContent>
-        <CardFooter>
-          <Button
-            type="button"
-            variant={"outline"}
-            onClick={() => updateFields?.(true)}
-            className="py-6"
-          >
-            <PlusCircleIcon className="w-8 h-8 mr-4" />
-            <span className="text-base">Add Sub Section</span>
-          </Button>
-        </CardFooter>
-      </Card>
-      <PopupDialog
-        open={modalState.open}
-        onCancel={() => {
-          setModalState((prev) => ({
-            ...prev,
-            open: false,
-            subsectionToDeleteIndex: undefined,
-          }));
-        }}
-        onConfirm={() => {
-          ["DELETE_SECTION", "DELETE_LAST_SUBSECTION"].includes(modalState.type)
-            ? deleteSection?.()
-            : updateFields?.(false, modalState.subsectionToDeleteIndex);
-          setModalState((prev) => ({
-            ...prev,
-            open: false,
-            subsectionToDeleteIndex: undefined,
-          }));
-        }}
-        title={TEXT_COPIES.MODAL?.[modalState.type].title}
-        description={TEXT_COPIES.MODAL?.[modalState.type].description}
-        cancelText={TEXT_COPIES.MODAL?.[modalState.type].cancelText}
-        confirmText={TEXT_COPIES.MODAL?.[modalState.type].confirmText}
+    <Card
+      data-card-type={SECTION.PROJECTS}
+      className="bg-brand-secondary-blue-1"
+    >
+      <HiddenInput
+        fieldName={
+          fieldName && (index !== undefined || index !== null)
+            ? `${fieldName}.${index}.type`
+            : undefined
+        }
+        value={SECTION.PROJECTS}
+        register={register}
       />
-    </>
+      <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
+        <CardTitle className="w-full max-w-[75%]">
+          <Label>Section Title:</Label>
+          <TextInput
+            fieldName={
+              fieldName && (index !== undefined || index !== null)
+                ? `${fieldName}.${index}.sectionTitle`
+                : undefined
+            }
+            register={register}
+            inputClassName="text-xl md:text-2xl py-6"
+            placeholder="Relevant Projects"
+            errorMessage={fieldErrors?.sectionTitle?.message}
+          />
+        </CardTitle>
+
+        <Button
+          className="ml-auto"
+          onClick={() => {
+            handleDelete();
+          }}
+          type="button"
+          variant={"ghost"}
+          title="Delete this section"
+        >
+          <Trash2Icon />
+        </Button>
+      </CardHeader>
+      <CardContent className="flex flex-wrap w-full gap-5">
+        {fields?.map((field, subSectionIndex) => (
+          <Card
+            className="w-full"
+            key={`projects-${index}-subsection-${subSectionIndex}`}
+          >
+            <CardHeader className="items-end">
+              <Button
+                type="button"
+                variant={"ghost"}
+                className="w-fit"
+                onClick={() =>
+                  handleDelete(subSectionIndex, fields.length === 1)
+                }
+                title="Delete this sub-section"
+              >
+                <Trash2Icon className=" w-5 h-5" />
+              </Button>
+            </CardHeader>
+            <CardContent className="flex flex-row flex-wrap gap-10">
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].projectTitle`
+                    : undefined
+                }
+                register={register}
+                label="Project Title"
+                placeholder="Jalebi Maker"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.projectTitle?.message
+                }
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].projectSubtitle`
+                    : undefined
+                }
+                label="Project Subtitle"
+                register={register}
+                placeholder="Food Tech, Electronics, Automation"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.projectSubtitle
+                    ?.message
+                }
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].projectUrl`
+                    : undefined
+                }
+                register={register}
+                label="Project Url"
+                autoComplete="url"
+                placeholder="www.jalebi-maker.com"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.projectUrl?.message
+                }
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].associatedWith`
+                    : undefined
+                }
+                register={register}
+                label="Associated with"
+                autoComplete="organization"
+                placeholder="Gada Electronics"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.associatedWith
+                    ?.message
+                }
+              />
+              <DurationInput
+                fieldName={`${fieldName}.[${index}].fields.[${subSectionIndex}].duration`}
+                subFieldNames={{
+                  startDate: "startDate",
+                  endDate: "endDate",
+                  current: "current",
+                }}
+                labels={{
+                  startDate: "Start Date",
+                  endDate: "End Date",
+                  current: "I am currently working on this project",
+                }}
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].details`
+                    : undefined
+                }
+                label="Description"
+                multiline
+                register={register}
+                placeholder={
+                  '- Created Jalebi Maker Machine- Goes well with "Chi Piyo, Biscuit Khao"\n-Got Funding from Gada Electronics'
+                }
+                className="w-full"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.details?.message
+                }
+              />
+            </CardContent>
+          </Card>
+        ))}
+      </CardContent>
+      <CardFooter>
+        <Button
+          type="button"
+          variant={"outline"}
+          onClick={() => updateFields?.(true)}
+          className="py-6"
+        >
+          <PlusCircleIcon className="w-8 h-8 mr-4" />
+          <span className="text-base">Add Sub Section</span>
+        </Button>
+      </CardFooter>
+    </Card>
   );
 };
 export default Projects;

--- a/src/components/global/form/form-sections/Skills.tsx
+++ b/src/components/global/form/form-sections/Skills.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext } from "react";
 import { PlusCircleIcon, Trash2Icon } from "lucide-react";
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
@@ -14,7 +14,7 @@ import {
 import { Label } from "@/components/ui/label";
 import HiddenInput from "@/components/global/form/form-inputs/HiddenInput";
 import TextInput from "@/components/global/form/form-inputs/TextInput";
-import PopupDialog from "../../dialog/PopupDialog";
+import { ModalStateContext } from "@/components/global/form/modal-state-provider";
 
 const fieldName = "optionalSections";
 
@@ -63,157 +63,153 @@ const Skills: React.FC<SkillsProps> = ({
   updateFields,
 }) => {
   const { register } = useFormContext<formType>();
-  const [modalState, setModalState] = useState<{
-    open: boolean;
-    type: "DELETE_SECTION" | "DELETE_SUBSECTION" | "DELETE_LAST_SUBSECTION";
-    subsectionToDeleteIndex?: number;
-  }>({
-    open: false,
-    type: "DELETE_SECTION",
-  });
+
+  const modalStateContext = useContext(ModalStateContext);
+
+  if (!modalStateContext) {
+    throw new Error(
+      "Additional section component must be used within a DynamicForm component"
+    );
+  }
+
+  const handleDelete = (
+    subSectionIndex?: number,
+    isLastSubsection?: boolean
+  ) => {
+    const modalTextKey = subSectionIndex
+      ? isLastSubsection
+        ? "DELETE_LAST_SUBSECTION"
+        : "DELETE_SUBSECTION"
+      : "DELETE_SECTION";
+
+    const onConfirm = () => {
+      if (subSectionIndex && !isLastSubsection) {
+        updateFields?.(false, subSectionIndex);
+      } else {
+        deleteSection?.();
+      }
+      modalStateContext.setModalState({ isOpen: false });
+    };
+
+    const onCancel = () => {
+      modalStateContext.setModalState({ isOpen: false });
+    };
+
+    modalStateContext.setModalState({
+      title: TEXT_COPIES.MODAL?.[modalTextKey].title,
+      message: TEXT_COPIES.MODAL?.[modalTextKey].description,
+      isOpen: true,
+      confirmText: TEXT_COPIES.MODAL?.[modalTextKey].confirmText,
+      cancelText: TEXT_COPIES.MODAL?.[modalTextKey].cancelText,
+      onConfirm,
+      onCancel,
+    });
+  };
 
   return (
-    <>
-      <Card
-        data-card-type={SECTION.PROJECTS}
-        className="bg-brand-secondary-blue-1"
-      >
-        <HiddenInput
-          fieldName={
-            fieldName && (index !== undefined || index !== null)
-              ? `${fieldName}.${index}.type`
-              : undefined
-          }
-          value={SECTION.PROJECTS}
-          register={register}
-        />
-        <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
-          <CardTitle className="w-full max-w-[75%]">
-            <Label>Section Title:</Label>
-            <TextInput
-              fieldName={
-                fieldName && (index !== undefined || index !== null)
-                  ? `${fieldName}.${index}.sectionTitle`
-                  : undefined
-              }
-              register={register}
-              inputClassName="text-xl md:text-2xl py-6"
-              placeholder="Technical Skills"
-              errorMessage={fieldErrors?.sectionTitle?.message}
-            />
-          </CardTitle>
-
-          <Button
-            className="ml-auto"
-            onClick={() => {
-              setModalState({
-                open: true,
-                type: "DELETE_SECTION",
-              });
-            }}
-            type="button"
-            variant={"ghost"}
-            title="Delete this section"
-          >
-            <Trash2Icon />
-          </Button>
-        </CardHeader>
-        <CardContent className="flex flex-wrap w-full gap-5">
-          {fields?.map((field, subSectionIndex) => (
-            <Card
-              className="w-full"
-              key={`projects-${index}-subsection-${subSectionIndex}`}
-            >
-              <CardContent className="mt-5 flex items-center">
-                <div className="flex flex-row flex-wrap gap-10 w-full">
-                  <TextInput
-                    fieldName={
-                      fieldName && (index !== undefined || index !== null)
-                        ? `${fieldName}.[${index}].fields.[${subSectionIndex}].title`
-                        : undefined
-                    }
-                    register={register}
-                    label="Skill Type"
-                    placeholder="Finance"
-                    className="w-full  md:max-w-[30%]"
-                    errorMessage={
-                      fieldErrors?.fields?.[subSectionIndex]?.title?.message
-                    }
-                  />
-                  <TextInput
-                    fieldName={
-                      fieldName && (index !== undefined || index !== null)
-                        ? `${fieldName}.[${index}].fields.[${subSectionIndex}].skills`
-                        : undefined
-                    }
-                    label="Skills"
-                    register={register}
-                    placeholder="Accounting, Calculator Expert, Tax Calculations, Counting Money ..."
-                    className="w-full lg:max-w-[60%] md:max-w-[55%]"
-                    errorMessage={
-                      fieldErrors?.fields?.[subSectionIndex]?.skills?.message
-                    }
-                  />
-                </div>
-                <Button
-                  type="button"
-                  variant={"ghost"}
-                  className="w-fit"
-                  onClick={() =>
-                    setModalState({
-                      open: true,
-                      type:
-                        fields.length > 1
-                          ? "DELETE_SUBSECTION"
-                          : "DELETE_LAST_SUBSECTION",
-                      subsectionToDeleteIndex: subSectionIndex,
-                    })
-                  }
-                  title="Delete this sub-section"
-                >
-                  <Trash2Icon className=" w-5 h-5" />
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
-        </CardContent>
-        <CardFooter>
-          <Button
-            type="button"
-            variant={"outline"}
-            onClick={() => updateFields?.(true)}
-            className="py-6"
-          >
-            <PlusCircleIcon className="w-8 h-8 mr-4" />
-            <span className="text-base">Add Sub Section</span>
-          </Button>
-        </CardFooter>
-      </Card>
-      <PopupDialog
-        open={modalState.open}
-        onCancel={() => {
-          setModalState((prev) => ({
-            ...prev,
-            open: false,
-            subsectionToDeleteIndex: undefined,
-          }));
-        }}
-        onConfirm={() => {
-          ["DELETE_SECTION", "DELETE_LAST_SUBSECTION"].includes(modalState.type)
-            ? deleteSection?.()
-            : updateFields?.(false, modalState.subsectionToDeleteIndex);
-          setModalState((prev) => ({
-            ...prev,
-            open: false,
-            subsectionToDeleteIndex: undefined,
-          }));
-        }}
-        title={TEXT_COPIES.MODAL?.[modalState.type].title}
-        description={TEXT_COPIES.MODAL?.[modalState.type].description}
-        cancelText={TEXT_COPIES.MODAL?.[modalState.type].cancelText}
-        confirmText={TEXT_COPIES.MODAL?.[modalState.type].confirmText}
+    <Card
+      data-card-type={SECTION.PROJECTS}
+      className="bg-brand-secondary-blue-1"
+    >
+      <HiddenInput
+        fieldName={
+          fieldName && (index !== undefined || index !== null)
+            ? `${fieldName}.${index}.type`
+            : undefined
+        }
+        value={SECTION.PROJECTS}
+        register={register}
       />
-    </>
+      <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
+        <CardTitle className="w-full max-w-[75%]">
+          <Label>Section Title:</Label>
+          <TextInput
+            fieldName={
+              fieldName && (index !== undefined || index !== null)
+                ? `${fieldName}.${index}.sectionTitle`
+                : undefined
+            }
+            register={register}
+            inputClassName="text-xl md:text-2xl py-6"
+            placeholder="Technical Skills"
+            errorMessage={fieldErrors?.sectionTitle?.message}
+          />
+        </CardTitle>
+
+        <Button
+          className="ml-auto"
+          onClick={() => handleDelete()}
+          type="button"
+          variant={"ghost"}
+          title="Delete this section"
+        >
+          <Trash2Icon />
+        </Button>
+      </CardHeader>
+      <CardContent className="flex flex-wrap w-full gap-5">
+        {fields?.map((field, subSectionIndex) => (
+          <Card
+            className="w-full"
+            key={`projects-${index}-subsection-${subSectionIndex}`}
+          >
+            <CardContent className="mt-5 flex items-center">
+              <div className="flex flex-row flex-wrap gap-10 w-full">
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].title`
+                      : undefined
+                  }
+                  register={register}
+                  label="Skill Type"
+                  placeholder="Finance"
+                  className="w-full  md:max-w-[30%]"
+                  errorMessage={
+                    fieldErrors?.fields?.[subSectionIndex]?.title?.message
+                  }
+                />
+                <TextInput
+                  fieldName={
+                    fieldName && (index !== undefined || index !== null)
+                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].skills`
+                      : undefined
+                  }
+                  label="Skills"
+                  register={register}
+                  placeholder="Accounting, Calculator Expert, Tax Calculations, Counting Money ..."
+                  className="w-full lg:max-w-[60%] md:max-w-[55%]"
+                  errorMessage={
+                    fieldErrors?.fields?.[subSectionIndex]?.skills?.message
+                  }
+                />
+              </div>
+              <Button
+                type="button"
+                variant={"ghost"}
+                className="w-fit"
+                onClick={() =>
+                  handleDelete(subSectionIndex, fields?.length === 1)
+                }
+                title="Delete this sub-section"
+              >
+                <Trash2Icon className=" w-5 h-5" />
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </CardContent>
+      <CardFooter>
+        <Button
+          type="button"
+          variant={"outline"}
+          onClick={() => updateFields?.(true)}
+          className="py-6"
+        >
+          <PlusCircleIcon className="w-8 h-8 mr-4" />
+          <span className="text-base">Add Sub Section</span>
+        </Button>
+      </CardFooter>
+    </Card>
   );
 };
 export default Skills;

--- a/src/components/global/form/form-sections/Skills.tsx
+++ b/src/components/global/form/form-sections/Skills.tsx
@@ -68,7 +68,7 @@ const Skills: React.FC<SkillsProps> = ({
 
   if (!modalStateContext) {
     throw new Error(
-      "Additional section component must be used within a DynamicForm component"
+      "Skills section component must be used within a DynamicForm component"
     );
   }
 

--- a/src/components/global/form/form-sections/WorkExperience.tsx
+++ b/src/components/global/form/form-sections/WorkExperience.tsx
@@ -69,7 +69,7 @@ const WorkExperience: React.FC<WorkExperienceProps> = ({
 
   if (!modalStateContext) {
     throw new Error(
-      "Additional section component must be used within a DynamicForm component"
+      "WorkExperience section component must be used within a DynamicForm component"
     );
   }
 

--- a/src/components/global/form/form-sections/WorkExperience.tsx
+++ b/src/components/global/form/form-sections/WorkExperience.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext } from "react";
 import { PlusCircleIcon, Trash2Icon } from "lucide-react";
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
@@ -12,10 +12,10 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
+import DurationInput from "@/components/global/form/form-inputs/DurationInput";
 import HiddenInput from "@/components/global/form/form-inputs/HiddenInput";
 import TextInput from "@/components/global/form/form-inputs/TextInput";
-import PopupDialog from "../../dialog/PopupDialog";
-import DurationInput from "../form-inputs/DurationInput";
+import { ModalStateContext } from "@/components/global/form/modal-state-provider";
 
 const fieldName = "optionalSections";
 
@@ -64,218 +64,216 @@ const WorkExperience: React.FC<WorkExperienceProps> = ({
   updateFields,
 }) => {
   const { register } = useFormContext<formType>();
-  const [modalState, setModalState] = useState<{
-    open: boolean;
-    type: "DELETE_SECTION" | "DELETE_SUBSECTION" | "DELETE_LAST_SUBSECTION";
-    subsectionToDeleteIndex?: number;
-  }>({
-    open: false,
-    type: "DELETE_SECTION",
-  });
+
+  const modalStateContext = useContext(ModalStateContext);
+
+  if (!modalStateContext) {
+    throw new Error(
+      "Additional section component must be used within a DynamicForm component"
+    );
+  }
+
+  const handleDelete = (
+    subSectionIndex?: number,
+    isLastSubsection?: boolean
+  ) => {
+    const modalTextKey = subSectionIndex
+      ? isLastSubsection
+        ? "DELETE_LAST_SUBSECTION"
+        : "DELETE_SUBSECTION"
+      : "DELETE_SECTION";
+
+    const onConfirm = () => {
+      if (subSectionIndex && !isLastSubsection) {
+        updateFields?.(false, subSectionIndex);
+      } else {
+        deleteSection?.();
+      }
+      modalStateContext.setModalState({ isOpen: false });
+    };
+
+    const onCancel = () => {
+      modalStateContext.setModalState({ isOpen: false });
+    };
+
+    modalStateContext.setModalState({
+      title: TEXT_COPIES.MODAL?.[modalTextKey].title,
+      message: TEXT_COPIES.MODAL?.[modalTextKey].description,
+      isOpen: true,
+      confirmText: TEXT_COPIES.MODAL?.[modalTextKey].confirmText,
+      cancelText: TEXT_COPIES.MODAL?.[modalTextKey].cancelText,
+      onConfirm,
+      onCancel,
+    });
+  };
 
   return (
-    <>
-      <Card
-        data-card-type={SECTION.WORK_EXPERIENCE}
-        className="bg-brand-secondary-blue-1"
-      >
-        <HiddenInput
-          fieldName={
-            fieldName && (index !== undefined || index !== null)
-              ? `${fieldName}.${index}.type`
-              : undefined
-          }
-          value={SECTION.WORK_EXPERIENCE}
-          register={register}
-        />
-        <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
-          <CardTitle className="w-full max-w-[75%]">
-            <Label>Section Title:</Label>
-            <TextInput
-              fieldName={
-                fieldName && (index !== undefined || index !== null)
-                  ? `${fieldName}.${index}.sectionTitle`
-                  : undefined
-              }
-              register={register}
-              inputClassName="text-xl md:text-2xl py-6"
-              placeholder="Section title"
-              errorMessage={fieldErrors?.sectionTitle?.message}
-            />
-          </CardTitle>
-
-          <Button
-            className="ml-auto"
-            onClick={() => {
-              setModalState({
-                open: true,
-                type: "DELETE_SECTION",
-              });
-            }}
-            type="button"
-            variant={"ghost"}
-            title="Delete this section"
-          >
-            <Trash2Icon />
-          </Button>
-        </CardHeader>
-        <CardContent className="flex flex-wrap w-full gap-5">
-          {fields?.map((field, subSectionIndex) => (
-            <Card
-              className="w-full"
-              key={`work-experience-${index}-subsection-${subSectionIndex}`}
-            >
-              <CardHeader className="items-end">
-                <Button
-                  type="button"
-                  variant={"ghost"}
-                  className="w-fit"
-                  onClick={() =>
-                    setModalState({
-                      open: true,
-                      type:
-                        fields.length > 1
-                          ? "DELETE_SUBSECTION"
-                          : "DELETE_LAST_SUBSECTION",
-                      subsectionToDeleteIndex: subSectionIndex,
-                    })
-                  }
-                  title="Delete this sub-section"
-                >
-                  <Trash2Icon className=" w-5 h-5" />
-                </Button>
-              </CardHeader>
-              <CardContent className="flex flex-row flex-wrap gap-10">
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].jobTitle`
-                      : undefined
-                  }
-                  register={register}
-                  label="Job Title"
-                  autoComplete="organization-title"
-                  placeholder="Jethalal Gada"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.jobTitle?.message
-                  }
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].jobSubtitle`
-                      : undefined
-                  }
-                  register={register}
-                  label="Job subtitle"
-                  placeholder="Jethalal Gada"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.jobSubtitle?.message
-                  }
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].companyName`
-                      : undefined
-                  }
-                  register={register}
-                  label="Company Name"
-                  autoComplete="organization"
-                  placeholder="Gada Electronics"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.companyName?.message
-                  }
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].location`
-                      : undefined
-                  }
-                  register={register}
-                  label="Location"
-                  autoComplete="address-level2"
-                  placeholder="Gokuldham Society"
-                  className="w-full lg:max-w-[30%] md:max-w-[45%]"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.location?.message
-                  }
-                />
-                <DurationInput
-                  fieldName={`${fieldName}.[${index}].fields.[${subSectionIndex}].duration`}
-                  subFieldNames={{
-                    startDate: "startDate",
-                    endDate: "endDate",
-                    current: "current",
-                  }}
-                  labels={{
-                    startDate: "Start Date",
-                    endDate: "End Date",
-                    current: "I an currently working here",
-                  }}
-                />
-                <TextInput
-                  fieldName={
-                    fieldName && (index !== undefined || index !== null)
-                      ? `${fieldName}.[${index}].fields.[${subSectionIndex}].details`
-                      : undefined
-                  }
-                  label="Description"
-                  multiline
-                  register={register}
-                  placeholder={
-                    "- Managed electronics store for 20+ years\n- Generated job opportunitites for many people\n- Earned a lot of money"
-                  }
-                  className="w-full"
-                  errorMessage={
-                    fieldErrors?.fields?.[subSectionIndex]?.details?.message
-                  }
-                />
-              </CardContent>
-            </Card>
-          ))}
-        </CardContent>
-        <CardFooter>
-          <Button
-            type="button"
-            variant={"outline"}
-            onClick={() => updateFields?.(true)}
-            className="py-6"
-          >
-            <PlusCircleIcon className="w-8 h-8 mr-4" />
-            <span className="text-base">Add Sub Section</span>
-          </Button>
-        </CardFooter>
-      </Card>
-      <PopupDialog
-        open={modalState.open}
-        onCancel={() => {
-          setModalState((prev) => ({
-            ...prev,
-            open: false,
-            subsectionToDeleteIndex: undefined,
-          }));
-        }}
-        onConfirm={() => {
-          ["DELETE_SECTION", "DELETE_LAST_SUBSECTION"].includes(modalState.type)
-            ? deleteSection?.()
-            : updateFields?.(false, modalState.subsectionToDeleteIndex);
-          setModalState((prev) => ({
-            ...prev,
-            open: false,
-            subsectionToDeleteIndex: undefined,
-          }));
-        }}
-        title={TEXT_COPIES.MODAL?.[modalState.type].title}
-        description={TEXT_COPIES.MODAL?.[modalState.type].description}
-        cancelText={TEXT_COPIES.MODAL?.[modalState.type].cancelText}
-        confirmText={TEXT_COPIES.MODAL?.[modalState.type].confirmText}
+    <Card
+      data-card-type={SECTION.WORK_EXPERIENCE}
+      className="bg-brand-secondary-blue-1"
+    >
+      <HiddenInput
+        fieldName={
+          fieldName && (index !== undefined || index !== null)
+            ? `${fieldName}.${index}.type`
+            : undefined
+        }
+        value={SECTION.WORK_EXPERIENCE}
+        register={register}
       />
-    </>
+      <CardHeader className="text-brand-neutral-11 flex flex-row flex-wrap w-full justify-between">
+        <CardTitle className="w-full max-w-[75%]">
+          <Label>Section Title:</Label>
+          <TextInput
+            fieldName={
+              fieldName && (index !== undefined || index !== null)
+                ? `${fieldName}.${index}.sectionTitle`
+                : undefined
+            }
+            register={register}
+            inputClassName="text-xl md:text-2xl py-6"
+            placeholder="Section title"
+            errorMessage={fieldErrors?.sectionTitle?.message}
+          />
+        </CardTitle>
+
+        <Button
+          className="ml-auto"
+          onClick={() => {
+            handleDelete();
+          }}
+          type="button"
+          variant={"ghost"}
+          title="Delete this section"
+        >
+          <Trash2Icon />
+        </Button>
+      </CardHeader>
+      <CardContent className="flex flex-wrap w-full gap-5">
+        {fields?.map((field, subSectionIndex) => (
+          <Card
+            className="w-full"
+            key={`work-experience-${index}-subsection-${subSectionIndex}`}
+          >
+            <CardHeader className="items-end">
+              <Button
+                type="button"
+                variant={"ghost"}
+                className="w-fit"
+                onClick={() =>
+                  handleDelete(subSectionIndex, fields?.length === 1)
+                }
+                title="Delete this sub-section"
+              >
+                <Trash2Icon className=" w-5 h-5" />
+              </Button>
+            </CardHeader>
+            <CardContent className="flex flex-row flex-wrap gap-10">
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].jobTitle`
+                    : undefined
+                }
+                register={register}
+                label="Job Title"
+                autoComplete="organization-title"
+                placeholder="Jethalal Gada"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.jobTitle?.message
+                }
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].jobSubtitle`
+                    : undefined
+                }
+                register={register}
+                label="Job subtitle"
+                placeholder="Jethalal Gada"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.jobSubtitle?.message
+                }
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].companyName`
+                    : undefined
+                }
+                register={register}
+                label="Company Name"
+                autoComplete="organization"
+                placeholder="Gada Electronics"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.companyName?.message
+                }
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].location`
+                    : undefined
+                }
+                register={register}
+                label="Location"
+                autoComplete="address-level2"
+                placeholder="Gokuldham Society"
+                className="w-full lg:max-w-[30%] md:max-w-[45%]"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.location?.message
+                }
+              />
+              <DurationInput
+                fieldName={`${fieldName}.[${index}].fields.[${subSectionIndex}].duration`}
+                subFieldNames={{
+                  startDate: "startDate",
+                  endDate: "endDate",
+                  current: "current",
+                }}
+                labels={{
+                  startDate: "Start Date",
+                  endDate: "End Date",
+                  current: "I an currently working here",
+                }}
+              />
+              <TextInput
+                fieldName={
+                  fieldName && (index !== undefined || index !== null)
+                    ? `${fieldName}.[${index}].fields.[${subSectionIndex}].details`
+                    : undefined
+                }
+                label="Description"
+                multiline
+                register={register}
+                placeholder={
+                  "- Managed electronics store for 20+ years\n- Generated job opportunitites for many people\n- Earned a lot of money"
+                }
+                className="w-full"
+                errorMessage={
+                  fieldErrors?.fields?.[subSectionIndex]?.details?.message
+                }
+              />
+            </CardContent>
+          </Card>
+        ))}
+      </CardContent>
+      <CardFooter>
+        <Button
+          type="button"
+          variant={"outline"}
+          onClick={() => updateFields?.(true)}
+          className="py-6"
+        >
+          <PlusCircleIcon className="w-8 h-8 mr-4" />
+          <span className="text-base">Add Sub Section</span>
+        </Button>
+      </CardFooter>
+    </Card>
   );
 };
 export default WorkExperience;

--- a/src/components/global/form/modal-state-provider.tsx
+++ b/src/components/global/form/modal-state-provider.tsx
@@ -21,8 +21,12 @@ type ModalStateContextType = {
   setModalState: (newState: ModalState) => void;
 };
 
-export const ModalStateContext =
-  React.createContext<ModalStateContextType | null>(null);
+export const ModalStateContext = React.createContext<ModalStateContextType>({
+  modalState: {
+    isOpen: false,
+  },
+  setModalState: () => console.warn("No modal state provider"),
+});
 
 const ModalStateProvider: React.FC<ModalStateProviderProps> = ({
   children,
@@ -31,19 +35,16 @@ const ModalStateProvider: React.FC<ModalStateProviderProps> = ({
     isOpen: false,
   });
 
-  const setModalStateHandler = useCallback(
-    (newState: ModalState) => {
-      setModalState(() => newState);
-    },
-    [modalState]
-  );
+  const setModalStateHandler = useCallback((newState: ModalState) => {
+    setModalState(() => newState);
+  }, []);
 
   const modalStateContextValue = React.useMemo(() => {
     return {
       modalState,
       setModalState: setModalStateHandler,
     };
-  }, [modalState]);
+  }, [modalState, setModalStateHandler]);
 
   return (
     <ModalStateContext.Provider value={modalStateContextValue}>

--- a/src/components/global/form/modal-state-provider.tsx
+++ b/src/components/global/form/modal-state-provider.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React, { useCallback, useEffect } from "react";
+
+type ModalStateProviderProps = {
+  children: React.ReactNode;
+};
+
+type ModalState = {
+  title?: string;
+  message?: string;
+  isOpen: boolean;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+};
+
+type ModalStateContextType = {
+  modalState: ModalState;
+  setModalState: (newState: ModalState) => void;
+};
+
+export const ModalStateContext =
+  React.createContext<ModalStateContextType | null>(null);
+
+const ModalStateProvider: React.FC<ModalStateProviderProps> = ({
+  children,
+}) => {
+  const [modalState, setModalState] = React.useState<ModalState>({
+    isOpen: false,
+  });
+
+  const setModalStateHandler = useCallback(
+    (newState: ModalState) => {
+      setModalState(() => newState);
+    },
+    [modalState]
+  );
+
+  const modalStateContextValue = React.useMemo(() => {
+    return {
+      modalState,
+      setModalState: setModalStateHandler,
+    };
+  }, [modalState]);
+
+  return (
+    <ModalStateContext.Provider value={modalStateContextValue}>
+      {children}
+    </ModalStateContext.Provider>
+  );
+};
+
+export default ModalStateProvider;


### PR DESCRIPTION
Issue:

<!-- NOTE: Each PR should be associated with an issue. Create an issue if it does not already exists -->

## Summary

Decluttered the forms delete/submit confirmation logic by having a single modal at root level and controlling it by using context.

## Testing done

Locally tested the changes
Existing tests pass

### Screenshots / Videos

No UI change
