### PR TITLE
Fix Login route breaks after session expired

### DIFF
--- a/__tests__/unit/hooks/authentication/useLogin.test.ts
+++ b/__tests__/unit/hooks/authentication/useLogin.test.ts
@@ -50,6 +50,7 @@ describe("useLogin", () => {
     ]);
     // Mock the axios post request
     (axios.post as jest.Mock).mockResolvedValue({ status: 200 });
+    (axios.get as jest.Mock).mockResolvedValue({ status: 200 });
   });
 
   afterEach(() => {


### PR DESCRIPTION
Issue: https://github.com/amlan-roy/resume-craft/issues/131

<!-- NOTE: Each PR should be associated with an issue. Create an issue if it does not already exists -->

## Summary

The issue was happening because the auth.currentUser was not being deleted as the user was actually never logged out from the client side.
Fixed that issue by updating the login hook to make get call to the login api route, and logging out the user in case the get request returns a error/logged out state and currentUser is still available locally.

## Details

<!-- Details of the changes made and things that the reviewer should focus on while reviewing the code -->

## Testing done

Tested the UI locally

### Screenshots / Videos

<!-- (Optional but recommended) -->

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
